### PR TITLE
Basic filtering by stored verbatim keywords/categories/themes

### DIFF
--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLCollectionsField.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLCollectionsField.java
@@ -12,6 +12,7 @@ public enum CQLCollectionsField {
     temporal(StacSummeries.Temporal.searchField, StacSummeries.Temporal.displayField),
     title(StacBasicField.Title.searchField, StacBasicField.Title.displayField),
     description(StacBasicField.Description.searchField, StacBasicField.Description.displayField),
+    categories(StacBasicField.Categories.searchField, StacBasicField.Categories.displayField),
     providers(StacBasicField.Providers.searchField, StacBasicField.Providers.displayField),
     id(StacBasicField.UUID.searchField, StacBasicField.UUID.displayField);
 

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLCollectionsField.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLCollectionsField.java
@@ -12,7 +12,7 @@ public enum CQLCollectionsField {
     temporal(StacSummeries.Temporal.searchField, StacSummeries.Temporal.displayField),
     title(StacBasicField.Title.searchField, StacBasicField.Title.displayField),
     description(StacBasicField.Description.searchField, StacBasicField.Description.displayField),
-    categories(StacBasicField.Categories.searchField, StacBasicField.Categories.displayField),
+    category(StacBasicField.Category.searchField, StacBasicField.Category.displayField),
     providers(StacBasicField.Providers.searchField, StacBasicField.Providers.displayField),
     id(StacBasicField.UUID.searchField, StacBasicField.UUID.displayField);
 

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/StacBasicField.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/StacBasicField.java
@@ -8,8 +8,8 @@ public enum StacBasicField {
             "providers",    // This result in the whole provider section return
             "providers.name"
     ),
-    Categories(
-            "categories",  // This result in the whole themes section return
+    Category(
+            "category",  // This result in the whole themes section return
             "themes.concepts.id"
     );
 

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/StacBasicField.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/StacBasicField.java
@@ -7,6 +7,10 @@ public enum StacBasicField {
     Providers(
             "providers",    // This result in the whole provider section return
             "providers.name"
+    ),
+    Categories(
+            "categories",  // This result in the whole themes section return
+            "themes.concepts.id"
     );
 
     public final String searchField;    // Field in STAC object

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
@@ -271,22 +271,10 @@ public class ElasticSearch implements Search {
             if(cql != null) {
                 CQLToElasticFilterFactory<CQLCollectionsField> factory = new CQLToElasticFilterFactory<>(coor, CQLCollectionsField.class);
                 Filter filter = CompilerUtil.parseFilter(Language.CQL, cql, factory);
-                // to enable search by multiple categories e.g ?filter=categories='cat1,cat2,cat3'
-                if (cql.startsWith("categories")) {
-                    String[] categories = cql.replace("'", "").split("=")[1].split("\\s*,\\s*");
-                    for (String category : categories) {
-                        filter = CompilerUtil.parseFilter(Language.CQL, "categories='" + category + "'", factory);
-                        if (filter instanceof ElasticFilter elasticFilterCategory) {
-                            filters.add(elasticFilterCategory.getQuery());
-                        }
-                    }
-                } else {
-                    if(filter instanceof ElasticFilter elasticFilter) {
-                        filters = List.of(elasticFilter.getQuery());
-                    }
+                if(filter instanceof ElasticFilter elasticFilter) {
+                    filters = List.of(elasticFilter.getQuery());
                 }
             }
-
             return searchCollectionBy(null, queries, filters,  properties, null, null);
         }
     }

--- a/server/src/test/java/au/org/aodn/ogcapi/server/core/common/RestApiTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/core/common/RestApiTest.java
@@ -351,13 +351,16 @@ public class RestApiTest extends BaseTestClass {
                 "7709f541-fc0c-4318-b5b9-9053aa474e0e.json"             // Provider is IMOS
         );
 
-        ResponseEntity<Collections> collections = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=categories='Saturation state of calcite in the water body'", Collections.class);
+        ResponseEntity<Collections> collections = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=category='Saturation state of calcite in the water body'", Collections.class);
         assertEquals(1, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 1, only one record");
 
-        collections = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=categories='Total alkalinity per unit mass of the water body, Practical salinity of the water body'", Collections.class);
+        collections = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=category='Total alkalinity per unit mass of the water body' AND category='Saturation state of calcite in the water body'", Collections.class);
         assertEquals(1, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 1, still partial match");
 
-        collections = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=categories='this category does not exist'", Collections.class);
+        collections = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=category='Total alkalinity per unit mass of the water body' OR category='this category does not exist'", Collections.class);
+        assertEquals(1, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 1, still partial match");
+
+        collections = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=category='this category does not exist'", Collections.class);
         assertEquals(0, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 0, order of words diff");
     }
     /**

--- a/server/src/test/java/au/org/aodn/ogcapi/server/core/common/RestApiTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/core/common/RestApiTest.java
@@ -343,6 +343,23 @@ public class RestApiTest extends BaseTestClass {
         collections = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=title='on stress coral reproduction.'", Collections.class);
         assertEquals(0, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 0, order of words diff");
     }
+
+    @Test
+    public void verifyParameterCategoriesSearchMatch() throws IOException  {
+        super.insertJsonToElasticIndex(
+                "516811d7-cd1e-207a-e0440003ba8c79dd.json",   // Provider null
+                "7709f541-fc0c-4318-b5b9-9053aa474e0e.json"             // Provider is IMOS
+        );
+
+        ResponseEntity<Collections> collections = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=categories='Saturation state of calcite in the water body'", Collections.class);
+        assertEquals(1, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 1, only one record");
+
+        collections = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=categories='Total alkalinity per unit mass of the water body, Practical salinity of the water body'", Collections.class);
+        assertEquals(1, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 1, still partial match");
+
+        collections = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=categories='this category does not exist'", Collections.class);
+        assertEquals(0, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 0, order of words diff");
+    }
     /**
      * Verify OR operation for CQL
      *


### PR DESCRIPTION
This PR allows to retrieve list of records based on category parameters; the categories are as-is from Geonetwork (stored under `themes` section in Elasticsearch (no grouping into higher level categories yet, which will be extended later; the syntax will remain the same when **"inferred high-level categories"** implemented/added to the records

multi categories

```syntax
http://localhost:8082/api/v1/ogc/collections?filter=category='Temperature of the water body' AND category='Turbidity of the water body'
```

or

single category

```syntax
http://localhost:8082/api/v1/ogc/collections?filter=category='Temperature of the water body'
```