### PR TITLE
Add centroid support

### DIFF
--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/mapper/Converter.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/mapper/Converter.java
@@ -3,7 +3,6 @@ package au.org.aodn.ogcapi.server.core.mapper;
 import au.org.aodn.ogcapi.features.model.*;
 import au.org.aodn.ogcapi.server.core.model.CitationModel;
 import au.org.aodn.ogcapi.server.core.model.ExtendedCollection;
-import au.org.aodn.ogcapi.server.core.model.LicenseModel;
 import au.org.aodn.ogcapi.server.core.model.StacCollectionModel;
 import au.org.aodn.ogcapi.server.core.model.enumeration.CollectionProperty;
 import au.org.aodn.ogcapi.server.core.util.ConstructUtils;
@@ -95,18 +94,6 @@ public interface Converter<F, T> {
                     .collect(Collectors.toList()));
         }
 
-        if (m.getSummaries() != null && m.getSummaries().getStatus() != null) {
-            collection.getProperties().put(CollectionProperty.status, m.getSummaries().getStatus());
-        }
-
-        if (m.getSummaries() != null && m.getSummaries().getCredits() != null) {
-            collection.getProperties().put(CollectionProperty.credits, m.getSummaries().getCredits());
-        }
-
-        if (m.getSummaries() != null && m.getSummaries().getGeometry() != null) {
-            collection.getProperties().put(CollectionProperty.geometry, m.getSummaries().getGeometry());
-        }
-
         if (m.getContacts() != null) {
             collection.getProperties().put(CollectionProperty.contacts, m.getContacts());
         }
@@ -115,30 +102,48 @@ public interface Converter<F, T> {
             collection.getProperties().put(CollectionProperty.themes, m.getThemes());
         }
 
-        if (m.getSummaries() != null && m.getSummaries().getTemporal() != null) {
-            collection.getProperties().put(CollectionProperty.temporal, m.getSummaries().getTemporal());
-        }
-
         if(m.getCitation() != null && !m.getCitation().isEmpty()) {
             ConstructUtils.constructByJsonString(m.getCitation(), CitationModel.class).ifPresent(
                     citation -> collection.getProperties().put(CollectionProperty.citation, citation)
             );
         }
 
-        if (m.getSummaries() != null && m.getSummaries().getStatement() != null) {
-            collection.getProperties().put(CollectionProperty.statement, m.getSummaries().getStatement());
-        }
-
         if (m.getLicense() != null) {
             collection.getProperties().put(CollectionProperty.license, m.getLicense());
         }
 
-        if (m.getSummaries() != null && m.getSummaries().getCreation() != null) {
-            collection.getProperties().put(CollectionProperty.creation, m.getSummaries().getCreation());
-        }
+        if(m.getSummaries() != null ) {
+            if (m.getSummaries().getCentroid() != null) {
+                collection.getProperties().put(CollectionProperty.centroid, m.getSummaries().getCentroid());
+            }
 
-        if (m.getSummaries() != null && m.getSummaries().getRevision() != null) {
-            collection.getProperties().put(CollectionProperty.revision, m.getSummaries().getRevision());
+            if (m.getSummaries().getStatus() != null) {
+                collection.getProperties().put(CollectionProperty.status, m.getSummaries().getStatus());
+            }
+
+            if (m.getSummaries().getCredits() != null) {
+                collection.getProperties().put(CollectionProperty.credits, m.getSummaries().getCredits());
+            }
+
+            if (m.getSummaries().getGeometry() != null) {
+                collection.getProperties().put(CollectionProperty.geometry, m.getSummaries().getGeometry());
+            }
+
+            if (m.getSummaries().getTemporal() != null) {
+                collection.getProperties().put(CollectionProperty.temporal, m.getSummaries().getTemporal());
+            }
+
+            if (m.getSummaries().getStatement() != null) {
+                collection.getProperties().put(CollectionProperty.statement, m.getSummaries().getStatement());
+            }
+
+            if (m.getSummaries().getCreation() != null) {
+                collection.getProperties().put(CollectionProperty.creation, m.getSummaries().getCreation());
+            }
+
+            if (m.getSummaries().getRevision() != null) {
+                collection.getProperties().put(CollectionProperty.revision, m.getSummaries().getRevision());
+            }
         }
 
         return collection;

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/model/SummariesModel.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/model/SummariesModel.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
@@ -18,6 +19,7 @@ public class SummariesModel {
     protected List<String> credits;
     protected String creation;
     protected String revision;
+    protected List<List<BigDecimal>> centroid;
 
     @JsonProperty("proj:geometry")
     protected Map<?,?> geometry;

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLFields.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLFields.java
@@ -49,6 +49,12 @@ public enum CQLFields implements CQLFieldsInterface {
             null,
             null
     ),
+    centroid(
+            StacSummeries.Centroid.searchField,
+            StacSummeries.Centroid.displayField,
+            null,
+            null
+    ),
     temporal(
             StacSummeries.Temporal.searchField,
             StacSummeries.Temporal.displayField,

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CollectionProperty.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CollectionProperty.java
@@ -18,6 +18,7 @@ public enum CollectionProperty {
     license("license"),
     creation("creation"),
     revision("revision"),
+    centroid("centroid"),
     ;
 
     private final String value;

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/StacSummeries.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/StacSummeries.java
@@ -3,6 +3,7 @@ package au.org.aodn.ogcapi.server.core.model.enumeration;
 import java.util.List;
 
 public enum StacSummeries {
+    Centroid("summaries.centroid","summaries.centroid"),
     Score("summaries.score", "summaries.score", "summaries.score", null),
     Geometry("summaries.proj:geometry","extent.bbox"),
     TemporalStart("summaries.temporal.start", ""),

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearchBase.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearchBase.java
@@ -2,15 +2,12 @@ package au.org.aodn.ogcapi.server.core.service;
 
 import au.org.aodn.ogcapi.server.core.model.StacCollectionModel;
 import au.org.aodn.ogcapi.server.core.model.enumeration.CQLFields;
-import au.org.aodn.ogcapi.server.core.model.enumeration.CQLElasticSetting;
 import au.org.aodn.ogcapi.server.core.model.enumeration.StacBasicField;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.*;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
-import co.elastic.clients.elasticsearch.core.CountRequest;
-import co.elastic.clients.elasticsearch.core.CountResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
@@ -23,7 +20,6 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.text.ParseException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -58,7 +54,7 @@ abstract class ElasticSearchBase {
      * @param must - The must portion of Elastic query
      * @param should - The should portion of Elastic query
      * @param filters - The filter to the Elastic query
-     * @return
+     * @return - A boolean query for elastic
      */
     protected BoolQuery createBoolQueryForProperties(List<Query> must, List<Query> should, List<Query> filters) {
         BoolQuery.Builder builder = new BoolQuery.Builder();
@@ -327,8 +323,6 @@ abstract class ElasticSearchBase {
         try {
             if(nodes != null) {
                 String json = nodes.toPrettyString();
-                log.debug("Serialize STAC json to StacCollectionModel {}", json);
-
                 return mapper.readValue(json, StacCollectionModel.class);
             }
             else {


### PR DESCRIPTION
Add support to a new attribute in CQL call centroid, it is a pre-calculate centroid point given the spatial extents removed the land area and split into grid, please refer to this PR for details -> https://github.com/aodn/es-indexer/pull/141