### PR TITLE
fix: duckdb version needs to be downgraded until we use newer docker base image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
 			<dependency>
 				<groupId>org.duckdb</groupId>
 				<artifactId>duckdb_jdbc</artifactId>
-				<version>1.3.2.0</version>
+				<version>1.0.0</version>
 			</dependency>
 			<!-- Add JSON layout dependency -->
 			<dependency>

--- a/server/src/main/java/au/org/aodn/ogcapi/server/features/RestServices.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/features/RestServices.java
@@ -107,7 +107,7 @@ public class RestServices extends OGCApiService {
 
                 Map<String, Object> properties = new HashMap<>();
                 properties.put("buoy", siteName);
-                properties.put("date", result.getDate("TIME"));
+                properties.put("date", result.getString("TIME").split(" ")[0]);
 
                 FeatureGeoJSON feature = new FeatureGeoJSON();
                 feature.setType(FeatureGeoJSON.TypeEnum.FEATURE);


### PR DESCRIPTION
# What happens?
DuckDB does not work when ogcapi runs on aws.
# Error
```{"instant":"2025-08-27T01:36:25.565Z","level":"ERROR","loggerName":"au.org.aodn.ogcapi.server.features.RestServices","message":"Error fetching features: Extension Autoloading Error: An error occurred while trying to automatically install the required extension 'httpfs':\nExtension \"/root/.duckdb/extensions/v1.3.2/linux_amd64/httpfs.duckdb_extension\" could not be loaded: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /root/.duckdb/extensions/v1.3.2/linux_amd64/httpfs.duckdb_extension)","endOfBatch":false,"threadId":29,"threadPriority":5,"service":"ogc-api"}```

# Details
Current version of duckdb used: 1.3.2.0 (latest), which only supports GLIBC version 2.28 or newer :https://github.com/duckdb/duckdb/releases/tag/v1.3.1

Downgraded to version 1.0.0 which supports versions 2.18 and above: https://github.com/duckdb/duckdb/releases/tag/v1.0.0