### PR TITLE
Feature/7786 use double quote search

### DIFF
--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
@@ -267,17 +267,28 @@ public class ElasticSearch extends ElasticSearchBase implements Search {
                 should = new ArrayList<>();
 
                 for (String t : keywords) {
-                    should.add(CQLFields.fuzzy_title.getPropertyEqualToQuery(t));
-                    should.add(CQLFields.fuzzy_desc.getPropertyEqualToQuery(t));
-                    should.add(CQLFields.parameter_vocabs.getPropertyEqualToQuery(t));
-                    should.add(CQLFields.organisation_vocabs.getPropertyEqualToQuery(t));
-                    should.add(CQLFields.platform_vocabs.getPropertyEqualToQuery(t));
-                    should.add(CQLFields.id.getPropertyEqualToQuery(t));
-                    // A request to not using acronym in title and description in metadata, hence these
-                    // acronym moved to links, for example NRMN record is mentioned in the link title.
-                    // This is a work-around to the requirement but still allow use of NRMN
-                    should.add(CQLFields.links_title_contains.getPropertyEqualToQuery(t));
-                    should.add(CQLFields.credit_contains.getPropertyEqualToQuery(t));
+                    // check if the text is in double quote - if so, use term query instead of fuzzy match
+                    boolean isExact = t.startsWith("\"") && t.endsWith("\"") && t.length() > 2;
+                    String term = isExact ? t.substring(1, t.length() - 1) : t;
+
+                    if (isExact) {
+                        // use exact term match, search in title and description
+                        should.add(CQLFields.title.getPropertyEqualToQuery(term));         // match term in original title text
+                        should.add(CQLFields.description.getPropertyEqualToQuery(term));   // match term in original description text
+                    }
+                    else {
+                        should.add(CQLFields.fuzzy_title.getPropertyEqualToQuery(t));
+                        should.add(CQLFields.fuzzy_desc.getPropertyEqualToQuery(t));
+                        should.add(CQLFields.parameter_vocabs.getPropertyEqualToQuery(t));
+                        should.add(CQLFields.organisation_vocabs.getPropertyEqualToQuery(t));
+                        should.add(CQLFields.platform_vocabs.getPropertyEqualToQuery(t));
+                        should.add(CQLFields.id.getPropertyEqualToQuery(t));
+                        // A request to not using acronym in title and description in metadata, hence these
+                        // acronym moved to links, for example NRMN record is mentioned in the link title.
+                        // This is a work-around to the requirement but still allow use of NRMN
+                        should.add(CQLFields.links_title_contains.getPropertyEqualToQuery(t));
+                        should.add(CQLFields.credit_contains.getPropertyEqualToQuery(t));
+                    }
                 }
             }
 

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
@@ -267,28 +267,35 @@ public class ElasticSearch extends ElasticSearchBase implements Search {
                 should = new ArrayList<>();
 
                 for (String t : keywords) {
-                    // check if the text is in double quote - if so, use term query instead of fuzzy match
+                    // If user's input (keywords) starts and ends with quote ", and the text is not empty
+                    // treat the user intend to search with the exact term,
+                    // instead of searching in fuzzy fields i.e., fuzzy_title and fuzzy_desc,
+                    // search in the original title and description fields
+                    // other fields are searched with the same term regardless of exact match or not, as they do not use fuzzy matching.
                     boolean isExact = t.startsWith("\"") && t.endsWith("\"") && t.length() > 2;
+                    // If search text with double quote, remove quotes,
+                    // otherwise keeps same
                     String term = isExact ? t.substring(1, t.length() - 1) : t;
 
                     if (isExact) {
-                        // use exact term match, search in title and description
-                        should.add(CQLFields.title.getPropertyEqualToQuery(term));         // match term in original title text
-                        should.add(CQLFields.description.getPropertyEqualToQuery(term));   // match term in original description text
+                        // Match phrase in original title and description, not use fuzzy fields
+                        should.add(CQLFields.title.getPropertyEqualToQuery(term));
+                        should.add(CQLFields.description.getPropertyEqualToQuery(term));
                     }
                     else {
-                        should.add(CQLFields.fuzzy_title.getPropertyEqualToQuery(t));
-                        should.add(CQLFields.fuzzy_desc.getPropertyEqualToQuery(t));
-                        should.add(CQLFields.parameter_vocabs.getPropertyEqualToQuery(t));
-                        should.add(CQLFields.organisation_vocabs.getPropertyEqualToQuery(t));
-                        should.add(CQLFields.platform_vocabs.getPropertyEqualToQuery(t));
-                        should.add(CQLFields.id.getPropertyEqualToQuery(t));
-                        // A request to not using acronym in title and description in metadata, hence these
-                        // acronym moved to links, for example NRMN record is mentioned in the link title.
-                        // This is a work-around to the requirement but still allow use of NRMN
-                        should.add(CQLFields.links_title_contains.getPropertyEqualToQuery(t));
-                        should.add(CQLFields.credit_contains.getPropertyEqualToQuery(t));
+                        should.add(CQLFields.fuzzy_title.getPropertyEqualToQuery(term));
+                        should.add(CQLFields.fuzzy_desc.getPropertyEqualToQuery(term));
                     }
+                    should.add(CQLFields.parameter_vocabs.getPropertyEqualToQuery(term));
+                    should.add(CQLFields.organisation_vocabs.getPropertyEqualToQuery(term));
+                    should.add(CQLFields.platform_vocabs.getPropertyEqualToQuery(term));
+                    should.add(CQLFields.id.getPropertyEqualToQuery(term));
+                    // A request to not using acronym in title and description in metadata, hence these
+                    // acronym moved to links, for example NRMN record is mentioned in the link title.
+                    // This is a work-around to the requirement but still allow use of NRMN
+                    // links_title_contains and credit_contains use match query by default, exact match is not applied here
+                    should.add(CQLFields.links_title_contains.getPropertyEqualToQuery(term));
+                    should.add(CQLFields.credit_contains.getPropertyEqualToQuery(term));
                 }
             }
 

--- a/server/src/test/java/au/org/aodn/ogcapi/server/service/ElasticSearchTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/service/ElasticSearchTest.java
@@ -4,6 +4,7 @@ import au.org.aodn.ogcapi.features.model.FeatureGeoJSON;
 import au.org.aodn.ogcapi.server.core.model.EsFeatureCollectionModel;
 import au.org.aodn.ogcapi.server.core.model.EsFeatureModel;
 import au.org.aodn.ogcapi.server.core.model.EsPolygonModel;
+import au.org.aodn.ogcapi.server.core.model.enumeration.CQLFields;
 import au.org.aodn.ogcapi.server.core.model.ogc.FeatureRequest;
 import au.org.aodn.ogcapi.server.core.service.ElasticSearch;
 import au.org.aodn.ogcapi.server.core.service.ElasticSearchBase;
@@ -13,6 +14,7 @@ import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
 import co.elastic.clients.elasticsearch.core.search.TotalHits;
+import co.elastic.clients.elasticsearch._types.query_dsl.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -114,6 +116,54 @@ public class ElasticSearchTest {
         assertTrue(featureProps.containsKey("key"));
         assertEquals("satellite_ghrsst_l4_gamssa_1day_multi_sensor_world.zarr",
                 featureProps.get("key"));
+    }
+
+    @Test
+    public void searchByParameters_withDoubleQuote_shouldUseExactMatch() throws Exception {
+        // text with double quote
+        String keyword = "\"ocean temperature\"";
+        List<String> keywords = List.of(keyword);
+
+        List<Query> should = new ArrayList<>();
+        for (String t : keywords) {
+            boolean isExact = t.startsWith("\"") && t.endsWith("\"") && t.length() > 2;
+            String term = isExact ? t.substring(1, t.length() - 1) : t;
+
+            if (isExact) {
+                should.add(CQLFields.title.getPropertyEqualToQuery(term));
+                should.add(CQLFields.description.getPropertyEqualToQuery(term));
+            }
+        }
+
+        // Assert
+        assertEquals(2, should.size(), "Exact match should only produce 2 queries (title + description)");
+        assertTrue(should.get(0).isMatchPhrase(), "Title query should be MatchPhraseQuery");
+        assertTrue(should.get(1).isMatchPhrase(), "Description query should be MatchPhraseQuery");
+    }
+
+    @Test
+    public void searchByParameters_withoutDoubleQuote_shouldUseFuzzyMatch() throws Exception {
+        String keyword = "ocean temperature";
+        List<String> keywords = List.of(keyword);
+
+        List<Query> should = new ArrayList<>();
+        for (String t : keywords) {
+            boolean isExact = t.startsWith("\"") && t.endsWith("\"") && t.length() > 2;
+
+            if (!isExact) {
+                should.add(CQLFields.fuzzy_title.getPropertyEqualToQuery(t));
+                should.add(CQLFields.fuzzy_desc.getPropertyEqualToQuery(t));
+                should.add(CQLFields.parameter_vocabs.getPropertyEqualToQuery(t));
+                should.add(CQLFields.organisation_vocabs.getPropertyEqualToQuery(t));
+                should.add(CQLFields.platform_vocabs.getPropertyEqualToQuery(t));
+                should.add(CQLFields.id.getPropertyEqualToQuery(t));
+                should.add(CQLFields.links_title_contains.getPropertyEqualToQuery(t));
+                should.add(CQLFields.credit_contains.getPropertyEqualToQuery(t));
+            }
+        }
+
+        assertEquals(8, should.size(), "Fuzzy match should produce 8 queries");
+        assertTrue(should.get(0).isMatch(), "fuzzy_title should be MatchQuery");
     }
 
 

--- a/server/src/test/java/au/org/aodn/ogcapi/server/service/ElasticSearchTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/service/ElasticSearchTest.java
@@ -119,52 +119,55 @@ public class ElasticSearchTest {
     }
 
     @Test
-    public void searchByParameters_withDoubleQuote_shouldUseExactMatch() throws Exception {
-        // text with double quote
+    public void searchByParametersWithDoubleQuote() throws Exception {
         String keyword = "\"ocean temperature\"";
         List<String> keywords = List.of(keyword);
-
         List<Query> should = new ArrayList<>();
         for (String t : keywords) {
             boolean isExact = t.startsWith("\"") && t.endsWith("\"") && t.length() > 2;
             String term = isExact ? t.substring(1, t.length() - 1) : t;
-
             if (isExact) {
                 should.add(CQLFields.title.getPropertyEqualToQuery(term));
                 should.add(CQLFields.description.getPropertyEqualToQuery(term));
+            } else {
+                should.add(CQLFields.fuzzy_title.getPropertyEqualToQuery(term));
+                should.add(CQLFields.fuzzy_desc.getPropertyEqualToQuery(term));
             }
+            should.add(CQLFields.parameter_vocabs.getPropertyEqualToQuery(term));
+            should.add(CQLFields.organisation_vocabs.getPropertyEqualToQuery(term));
+            should.add(CQLFields.platform_vocabs.getPropertyEqualToQuery(term));
+            should.add(CQLFields.id.getPropertyEqualToQuery(term));
+            should.add(CQLFields.links_title_contains.getPropertyEqualToQuery(term));
+            should.add(CQLFields.credit_contains.getPropertyEqualToQuery(term));
         }
-
-        // Assert
-        assertEquals(2, should.size(), "Exact match should only produce 2 queries (title + description)");
+        assertEquals(8, should.size(), "Exact match should produce 8 queries (title + description + other fields)");
         assertTrue(should.get(0).isMatchPhrase(), "Title query should be MatchPhraseQuery");
         assertTrue(should.get(1).isMatchPhrase(), "Description query should be MatchPhraseQuery");
     }
 
     @Test
-    public void searchByParameters_withoutDoubleQuote_shouldUseFuzzyMatch() throws Exception {
+    public void searchByParametersWithoutDoubleQuote() throws Exception {
         String keyword = "ocean temperature";
         List<String> keywords = List.of(keyword);
-
         List<Query> should = new ArrayList<>();
         for (String t : keywords) {
             boolean isExact = t.startsWith("\"") && t.endsWith("\"") && t.length() > 2;
-
-            if (!isExact) {
-                should.add(CQLFields.fuzzy_title.getPropertyEqualToQuery(t));
-                should.add(CQLFields.fuzzy_desc.getPropertyEqualToQuery(t));
-                should.add(CQLFields.parameter_vocabs.getPropertyEqualToQuery(t));
-                should.add(CQLFields.organisation_vocabs.getPropertyEqualToQuery(t));
-                should.add(CQLFields.platform_vocabs.getPropertyEqualToQuery(t));
-                should.add(CQLFields.id.getPropertyEqualToQuery(t));
-                should.add(CQLFields.links_title_contains.getPropertyEqualToQuery(t));
-                should.add(CQLFields.credit_contains.getPropertyEqualToQuery(t));
+            String term = isExact ? t.substring(1, t.length() - 1) : t;
+            if (isExact) {
+                should.add(CQLFields.title.getPropertyEqualToQuery(term));
+                should.add(CQLFields.description.getPropertyEqualToQuery(term));
+            } else {
+                should.add(CQLFields.fuzzy_title.getPropertyEqualToQuery(term));
+                should.add(CQLFields.fuzzy_desc.getPropertyEqualToQuery(term));
             }
+            should.add(CQLFields.parameter_vocabs.getPropertyEqualToQuery(term));
+            should.add(CQLFields.organisation_vocabs.getPropertyEqualToQuery(term));
+            should.add(CQLFields.platform_vocabs.getPropertyEqualToQuery(term));
+            should.add(CQLFields.id.getPropertyEqualToQuery(term));
+            should.add(CQLFields.links_title_contains.getPropertyEqualToQuery(term));
+            should.add(CQLFields.credit_contains.getPropertyEqualToQuery(term));
         }
-
         assertEquals(8, should.size(), "Fuzzy match should produce 8 queries");
         assertTrue(should.get(0).isMatch(), "fuzzy_title should be MatchQuery");
     }
-
-
 }


### PR DESCRIPTION
Currently, if we search with text, it executes a fuzzy match, so if search with `ARGOS`, argo comes as well. This is not expected according to user [feedback](https://utas.atlassian.net/wiki/spaces/IMOS/pages/1212121160/Focus+group+test+feedback+action+taken): 
> Things that have ARGOS communication system (shelf drifters, gliders, seal-ctd, AUVs, moorings,….). ARGOS is not the same as Argo, and these instruments should not be grouped together.
<img width="1609" height="648" alt="image" src="https://github.com/user-attachments/assets/47c875ee-7bb3-49e3-b815-0956cb603275" />

So allow exact search with term if user type text with double quote:
<img width="1645" height="659" alt="image" src="https://github.com/user-attachments/assets/a2b6556b-4afe-4eca-8d72-9f13039a5c21" />

Query:
~[DEV] 2026-04-13 16:55:20 DEBUG ElasticSearchBase:373 - Elastic search payload for count CountRequest: POST /es-indexer-edge/_count {"query":{"script_score":{"query":{"bool":{"filter":[{"geo_bounding_box":{"summaries.proj:geometry":{"top_left":{"lat":-8.0,"lon":104.0},"bottom_right":{"lat":-43.0,"lon":163.0}}}}],"minimum_should_match":"1","must":[{"match_all":{}}],"should":[{"match_phrase":{"title":{"query":"ARGOS"}}},{"match_phrase":{"description":{"query":"ARGOS"}}}]}},"script":{"source":"double internalScore = doc.containsKey('summaries.score') && !doc['summaries.score'].empty ? doc['summaries.score'].value : 0.0; double normalizedScore = internalScore / 106.0; double multiplier = Math.max(normalizedScore, 0.01); return _score * multiplier;","lang":"painless"}}}}~
```
[DEV] 2026-04-14 10:21:35 DEBUG ElasticSearchBase:373 - Elastic search payload for count CountRequest: POST /es-indexer-edge/_count {"query":{"script_score":{"query":{"bool":{"filter":[{"geo_bounding_box":{"summaries.proj:geometry":{"top_left":{"lat":-8.0,"lon":104.0},"bottom_right":{"lat":-43.0,"lon":163.0}}}}],"minimum_should_match":"1","must":[{"match_all":{}}],"should":[{"match_phrase":{"title":{"query":"ARGOS"}}},{"match_phrase":{"description":{"query":"ARGOS"}}},{"match_phrase":{"summaries.parameter_vocabs":{"query":"ARGOS"}}},{"match_phrase":{"summaries.organisation_vocabs":{"query":"ARGOS"}}},{"match_phrase":{"summaries.platform_vocabs":{"query":"ARGOS"}}},{"match_phrase":{"id":{"boost":100.0,"query":"ARGOS"}}},{"nested":{"path":"links","query":{"match":{"links.title":{"query":"ARGOS"}}}}},{"match":{"summaries.credits":{"query":"ARGOS"}}}]}},"script":{"source":"double internalScore = doc.containsKey('summaries.score') && !doc['summaries.score'].empty ? doc['summaries.score'].value : 0.0; double normalizedScore = internalScore / 106.0; double multiplier = Math.max(normalizedScore, 0.01); return _score * multiplier;","lang":"painless"}}}}
```

