### PR TITLE
Bugfix/8516 meow filter fix

### DIFF
--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/configuration/Config.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/configuration/Config.java
@@ -30,8 +30,13 @@ public class Config {
     public void init() {
         // register modudle for json serializing
         mapper.registerModule(new JsonNullableModule());
-        // configure ObjectMapper to exclude null fields while serializing
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        // Configure ObjectMapper to exclude null fields while serializing
+        mapper.setDefaultPropertyInclusion(
+                JsonInclude.Value.construct(
+                        JsonInclude.Include.NON_NULL,
+                        JsonInclude.Include.USE_DEFAULTS
+                )
+        );
     }
 
     @Bean

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/IBoundaryFunction.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/IBoundaryFunction.java
@@ -34,7 +34,12 @@ public class IBoundaryFunction extends FunctionImpl {
                     if (properties != null) {
                         JsonNode objectId = properties.get(keyField);
                         if (objectId != null) {
-                            String key = objectId.asText();
+                            // This is used to avoid the trailing zeros in the number, for example 123.0 in key,
+                            // where the React frontend with javascript number type will parse the number to 123
+                            // and cause the key mismatch with the map.
+                            final String key = objectId.isNumber()
+                                    ? objectId.decimalValue().stripTrailingZeros().toPlainString()
+                                    : objectId.asText();
                             JsonNode geometry = feature.get("geometry");
                             if (geometry != null) {
                                 String geoJson = mapper.writeValueAsString(geometry);
@@ -82,8 +87,11 @@ public class IBoundaryFunction extends FunctionImpl {
     public Object evaluate(Object feature) {
         String name = getParameters().get(0).evaluate(feature, String.class);
         String id = getParameters().get(1).evaluate(feature, String.class);
-
-        return getGeoJsonFromMap(name, id);
+        Geometry geometry = getGeoJsonFromMap(name, id);
+        if(geometry == null) {
+            log.warn("IBoundaryFunction lookup failed: name={}, id={}", name, id);
+        }
+        return geometry;
     }
 
     @Override

--- a/server/src/test/java/au/org/aodn/ogcapi/server/core/parser/elastic/IBoundaryFunctionTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/core/parser/elastic/IBoundaryFunctionTest.java
@@ -32,6 +32,15 @@ public class IBoundaryFunctionTest {
     }
 
     @Test
+    public void testMeowKeyNormalization() {
+        // Meow.json has ECO_CODE like 20192.0 (as JSON number), React/JS does String(20192.0) === '20192'
+        // so loadStaticMap must store keys without trailing .0 to avoid lookup mismatch
+        assertNotNull(IBoundaryFunction.MEOW.get("20192"), "Expected key '20192' for MEOW (from 20192.0)");
+        assertNotNull(IBoundaryFunction.MEOW.get("20053"));
+        assertNull(IBoundaryFunction.MEOW.get("20192.0"), "Should not have .0 suffixed key");
+    }
+
+    @Test
     public void testIBoundaryWithCQL() throws Exception {
         // Parse full CQL2 string
         String cql = "INTERSECTS(geometry, IBOUNDARY('ACA', '1'))";


### PR DESCRIPTION
The meow area id can be number with decimal, for example 123.0
This value will parsed  by react as 123 hence unmatched with the key lookup in ogc-api. Fix by follow the React parsing for key