### PR TITLE
Feature/8213 reranking ai prediction

### DIFF
--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLFields.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLFields.java
@@ -137,12 +137,12 @@ public enum CQLFields implements CQLFieldsInterface {
                         StacBasicField.ParameterVocabs.searchField,
                         StacBasicField.ParameterVocabs.displayField,
                         null,
-                        null),
+                        vocabPrioritySortBuilder(StacBasicField.ParameterVocabs.searchField)),
         platform_vocabs(
                         StacBasicField.PlatformVocabs.searchField,
                         StacBasicField.PlatformVocabs.displayField,
                         null,
-                        null),
+                        vocabPrioritySortBuilder(StacBasicField.PlatformVocabs.searchField)),
         ai_parameter_vocabs(
                         StacSummeries.AiParameterVocabs.searchField,
                         StacSummeries.AiParameterVocabs.displayField,
@@ -304,6 +304,16 @@ public enum CQLFields implements CQLFieldsInterface {
                 this.displayField = displayField;
                 this.overridePropertyEqualsToQuery = overridePropertyEqualsToQuery;
                 this.sortBuilder = sortBuilder;
+        }
+
+        private static Function<SortOrder, ObjectBuilder<SortOptions>> vocabPrioritySortBuilder(String vocabField) {
+                return (order) -> new SortOptions.Builder().script(s -> s
+                                .type(ScriptSortType.Number)
+                                .script(sc -> sc
+                                                .lang("painless")
+                                                .source("return doc.containsKey('" + vocabField + ".keyword') && "
+                                                                + "!doc['" + vocabField + ".keyword'].empty ? 1 : 0;"))
+                                .order(order));
         }
 
         @Override

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactory.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactory.java
@@ -64,15 +64,29 @@ public class CQLToElasticFilterFactory<T extends Enum<T> & CQLFieldsInterface> i
     @Getter
     protected Map<CQLElasticSetting, String> querySetting;
 
+    /**
+     * Indicates that a parameter vocabulary filter was found and curated parameter values (parameter_vocabs) should
+     * be prioritised in the Elasticsearch result ordering.
+     */
     @Getter
     protected boolean parameterPrioritySort = false;
 
+    /**
+     * Parameter vocabulary values collected from equality filters while parsing the CQL query.
+     */
     @Getter
     protected Set<String> parameterPrioritySortTerms = new HashSet<>();
 
+    /**
+     * Indicates that a platform vocabulary filter was found and curated platform values (platform_vocabs) should be
+     * prioritised in the Elasticsearch result ordering.
+     */
     @Getter
     protected boolean platformPrioritySort = false;
 
+    /**
+     * Platform vocabulary values collected from equality filters while parsing the CQL query.
+     */
     @Getter
     protected Set<String> platformPrioritySortTerms = new HashSet<>();
 
@@ -267,6 +281,22 @@ public class CQLToElasticFilterFactory<T extends Enum<T> & CQLFieldsInterface> i
         return equal(expression, expression1, b, null);
     }
 
+    /**
+     * Creates an Elasticsearch equality filter and records metadata used to build the search
+     * request.
+     *
+     * <p>Query-setting expressions such as {@code page_size=11} are stored in
+     * {@link #querySetting} and returned without creating a normal Elasticsearch field query.
+     * Equality filters on {@code parameter_vocabs} or {@code platform_vocabs} enable the
+     * corresponding priority sort and collect the literal filter value. All other expressions are
+     * converted directly to a {@link PropertyEqualToImpl}.
+     *
+     * @param expression the field expression on the left side of the equality comparison
+     * @param expression1 the value expression on the right side of the equality comparison
+     * @param b whether string comparison should be case-sensitive
+     * @param matchAction how a multi-valued property should be matched
+     * @return an Elasticsearch query setting or equality filter
+     */
     @Override
     public PropertyIsEqualTo equal(Expression expression, Expression expression1, boolean b, MultiValuedFilter.MatchAction matchAction) {
         logger.debug("PropertyIsEqualTo {} {}, {} {}", expression, expression1, b, matchAction);
@@ -279,8 +309,7 @@ public class CQLToElasticFilterFactory<T extends Enum<T> & CQLFieldsInterface> i
             return setting;
         }
 
-        // If the filter compares curated vocab fields, collect the searched term so the caller can
-        // add a value-aware sort key that ranks matching human-curated records above AI ones.
+        // Record curated vocabulary filters so the search service can prioritise curated records.
         if (expression instanceof AttributeExpressionImpl attribute && expression1 instanceof LiteralExpressionImpl literal) {
             String fieldName = attribute.toString().toLowerCase();
             if (fieldName.equals("parameter_vocabs")) {

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactory.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactory.java
@@ -64,6 +64,12 @@ public class CQLToElasticFilterFactory<T extends Enum<T> & CQLFieldsInterface> i
     @Getter
     protected Map<CQLElasticSetting, String> querySetting;
 
+    @Getter
+    protected boolean parameterPrioritySort = false;
+
+    @Getter
+    protected Set<String> parameterPrioritySortTerms = new HashSet<>();
+
     public CQLToElasticFilterFactory(CQLCrsType cqlCoorSystem, Class<T> tClass) {
         this(cqlCoorSystem, tClass, new HashMap<>());
     }
@@ -265,6 +271,16 @@ public class CQLToElasticFilterFactory<T extends Enum<T> & CQLFieldsInterface> i
         if(setting.isValid()) {
             querySetting.put(setting.getElasticSettingName(), setting.getElasticSettingValue());
             return setting;
+        }
+
+        // If the filter compares parameter_vocabs, collect the searched term so the caller can
+        // add a value-aware sort key that ranks matching human-curated records above AI ones.
+        if (expression instanceof AttributeExpressionImpl attribute && expression1 instanceof LiteralExpressionImpl literal) {
+            String fieldName = attribute.toString().toLowerCase();
+            if (fieldName.equals("parameter_vocabs")) {
+                this.parameterPrioritySort = true;
+                this.parameterPrioritySortTerms.add(literal.toString());
+            }
         }
 
         return new PropertyEqualToImpl<>(expression, expression1, b, matchAction, collectionFieldType);

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactory.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactory.java
@@ -72,23 +72,11 @@ public class CQLToElasticFilterFactory<T extends Enum<T> & CQLFieldsInterface> i
     protected boolean parameterPrioritySort = false;
 
     /**
-     * Parameter vocabulary values collected from equality filters while parsing the CQL query.
-     */
-    @Getter
-    protected Set<String> parameterPrioritySortTerms = new HashSet<>();
-
-    /**
      * Indicates that a platform vocabulary filter was found and curated platform values (platform_vocabs) should be
      * prioritised in the Elasticsearch result ordering.
      */
     @Getter
     protected boolean platformPrioritySort = false;
-
-    /**
-     * Platform vocabulary values collected from equality filters while parsing the CQL query.
-     */
-    @Getter
-    protected Set<String> platformPrioritySortTerms = new HashSet<>();
 
     public CQLToElasticFilterFactory(CQLCrsType cqlCoorSystem, Class<T> tClass) {
         this(cqlCoorSystem, tClass, new HashMap<>());
@@ -297,15 +285,13 @@ public class CQLToElasticFilterFactory<T extends Enum<T> & CQLFieldsInterface> i
         }
 
         // Record curated vocabulary filters so the search service can prioritise curated records.
-        if (expression instanceof AttributeExpressionImpl attribute && expression1 instanceof LiteralExpressionImpl literal) {
+        if (expression instanceof AttributeExpressionImpl attribute && expression1 instanceof LiteralExpressionImpl) {
             String fieldName = attribute.toString().toLowerCase();
             if (fieldName.equals("parameter_vocabs")) {
                 this.parameterPrioritySort = true;
-                this.parameterPrioritySortTerms.add(literal.toString());
             }
             if (fieldName.equals("platform_vocabs")) {
                 this.platformPrioritySort = true;
-                this.platformPrioritySortTerms.add(literal.toString());
             }
         }
 

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactory.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactory.java
@@ -282,20 +282,7 @@ public class CQLToElasticFilterFactory<T extends Enum<T> & CQLFieldsInterface> i
     }
 
     /**
-     * Creates an Elasticsearch equality filter and records metadata used to build the search
-     * request.
-     *
-     * <p>Query-setting expressions such as {@code page_size=11} are stored in
-     * {@link #querySetting} and returned without creating a normal Elasticsearch field query.
-     * Equality filters on {@code parameter_vocabs} or {@code platform_vocabs} enable the
-     * corresponding priority sort and collect the literal filter value. All other expressions are
-     * converted directly to a {@link PropertyEqualToImpl}.
-     *
-     * @param expression the field expression on the left side of the equality comparison
-     * @param expression1 the value expression on the right side of the equality comparison
-     * @param b whether string comparison should be case-sensitive
-     * @param matchAction how a multi-valued property should be matched
-     * @return an Elasticsearch query setting or equality filter
+     * Creates an Elasticsearch equality filter and records metadata used to build the search request.
      */
     @Override
     public PropertyIsEqualTo equal(Expression expression, Expression expression1, boolean b, MultiValuedFilter.MatchAction matchAction) {

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactory.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactory.java
@@ -70,6 +70,12 @@ public class CQLToElasticFilterFactory<T extends Enum<T> & CQLFieldsInterface> i
     @Getter
     protected Set<String> parameterPrioritySortTerms = new HashSet<>();
 
+    @Getter
+    protected boolean platformPrioritySort = false;
+
+    @Getter
+    protected Set<String> platformPrioritySortTerms = new HashSet<>();
+
     public CQLToElasticFilterFactory(CQLCrsType cqlCoorSystem, Class<T> tClass) {
         this(cqlCoorSystem, tClass, new HashMap<>());
     }
@@ -273,13 +279,17 @@ public class CQLToElasticFilterFactory<T extends Enum<T> & CQLFieldsInterface> i
             return setting;
         }
 
-        // If the filter compares parameter_vocabs, collect the searched term so the caller can
+        // If the filter compares curated vocab fields, collect the searched term so the caller can
         // add a value-aware sort key that ranks matching human-curated records above AI ones.
         if (expression instanceof AttributeExpressionImpl attribute && expression1 instanceof LiteralExpressionImpl literal) {
             String fieldName = attribute.toString().toLowerCase();
             if (fieldName.equals("parameter_vocabs")) {
                 this.parameterPrioritySort = true;
                 this.parameterPrioritySortTerms.add(literal.toString());
+            }
+            if (fieldName.equals("platform_vocabs")) {
+                this.platformPrioritySort = true;
+                this.platformPrioritySortTerms.add(literal.toString());
             }
         }
 

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/OrImpl.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/OrImpl.java
@@ -14,59 +14,54 @@ public class OrImpl extends QueryHandler implements Or {
 
     protected List<Filter> children = new ArrayList<>();
 
+    private static List<Query> collectQueries(Filter filter) {
+        if (filter instanceof OrImpl orFilter) {
+            return orFilter.getChildren().stream()
+                    .flatMap(child -> collectQueries(child).stream())
+                    .toList();
+        }
+
+        if (filter instanceof QueryHandler handler && handler.getQuery() != null) {
+            return List.of(handler.getQuery());
+        }
+
+        return List.of();
+    }
+
+    private void buildQuery(List<Filter> filters) {
+        List<Query> queries = filters.stream()
+                .flatMap(filter -> collectQueries(filter).stream())
+                .toList();
+
+        if (queries.size() == 1) {
+            this.query = queries.get(0);
+        } else if (!queries.isEmpty()) {
+            this.query = BoolQuery.of(b -> b.should(queries))._toQuery();
+        }
+    }
+
     public OrImpl(Filter filter1, Filter filter2) {
+        children.add(filter1);
+        children.add(filter2);
 
-        if(filter1 instanceof ElasticSetting && filter2 instanceof QueryHandler elasticFilter2) {
-            this.addErrors(elasticFilter2.getErrors());
-            throw new IllegalArgumentException("Or combine with query setting do not make sense");
+        buildQuery(children);
+
+        if (filter1 instanceof QueryHandler handler) {
+            addErrors(handler.getErrors());
         }
-        else if(filter2 instanceof ElasticSetting && filter1 instanceof QueryHandler elasticFilter1){
-            this.addErrors(elasticFilter1.getErrors());
-            throw new IllegalArgumentException("Or combine with query setting do not make sense");
-        }
-        else if(filter1 instanceof QueryHandler elasticFilter1 && filter2 instanceof QueryHandler elasticFilter2) {
-            // If the CQL contains ElasticSetting then the query will be null, this check is used to make sure
-            // we ignore those null query
-            if(elasticFilter1.query != null && elasticFilter2.query != null) {
-                this.query = BoolQuery.of(f -> f
-                        .should(elasticFilter1.query, elasticFilter2.query)
-                )._toQuery();
-            }
-            else if(elasticFilter1.query != null) {
-                this.query = elasticFilter1.query;
-            }
-            else {
-                this.query = elasticFilter2.query;
-            }
-
-            children.add(filter1);
-            children.add(filter2);
-
-            // Remember to copy the error from child
-            this.addErrors(elasticFilter1.getErrors());
-            this.addErrors(elasticFilter2.getErrors());
+        if (filter2 instanceof QueryHandler handler) {
+            addErrors(handler.getErrors());
         }
     }
 
     public OrImpl(List<Filter> filters) {
-        // Extract query object in the filters, it must be an ElasitcFilter
-        List<QueryHandler> elasticFilters = filters.stream()
-                .filter(f -> f instanceof QueryHandler)
-                .map(m -> (QueryHandler)m)
-                .collect(Collectors.toList());
-
-        List<Query> queries = elasticFilters.stream()
-                .map(m -> m.query)
-                .collect(Collectors.toList());
-
-        this.query = BoolQuery.of(f -> f
-                .should(queries))
-                ._toQuery();
-
         children.addAll(filters);
+        buildQuery(children);
 
-        // Copy child error if any
-        elasticFilters.stream().forEach(elasticFilter -> {this.addErrors(elasticFilter.getErrors());});
+        filters.stream()
+                .filter(QueryHandler.class::isInstance)
+                .map(QueryHandler.class::cast)
+                .forEach(handler -> addErrors(handler.getErrors()));
     }
 
     @Override

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/OrImpl.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/OrImpl.java
@@ -8,12 +8,15 @@ import org.opengis.filter.Or;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class OrImpl extends QueryHandler implements Or {
 
     protected List<Filter> children = new ArrayList<>();
 
+    /**
+     * Recursively extracts leaf Elasticsearch queries from nested OR filters and returns them as a flat list.
+     * The caller uses this list to construct a single bool/should query.
+     */
     private static List<Query> collectQueries(Filter filter) {
         if (filter instanceof OrImpl orFilter) {
             return orFilter.getChildren().stream()
@@ -28,6 +31,14 @@ public class OrImpl extends QueryHandler implements Or {
         return List.of();
     }
 
+
+    /**
+     * Builds the Elasticsearch representation of an OR expression.
+     *
+     * A single query is returned directly. Multiple queries are combined into
+     * one flat bool/should query to avoid deeply nested bool queries for large
+     * vocabulary selections.
+     */
     private void buildQuery(List<Filter> filters) {
         List<Query> queries = filters.stream()
                 .flatMap(filter -> collectQueries(filter).stream())
@@ -54,6 +65,8 @@ public class OrImpl extends QueryHandler implements Or {
         }
     }
 
+    // Flatten the bool should query so that to avoid when many parameters are selected,
+    // the nested query cause Elasticsearch error
     public OrImpl(List<Filter> filters) {
         children.addAll(filters);
         buildQuery(children);

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/OrImpl.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/OrImpl.java
@@ -13,6 +13,15 @@ public class OrImpl extends QueryHandler implements Or {
 
     protected List<Filter> children = new ArrayList<>();
 
+    private static boolean containsElasticSetting(Filter filter) {
+        if (filter instanceof ElasticSetting) {
+            return true;
+        }
+
+        return filter instanceof OrImpl orFilter
+                && orFilter.getChildren().stream().anyMatch(OrImpl::containsElasticSetting);
+    }
+
     /**
      * Recursively extracts leaf Elasticsearch queries from nested OR filters and returns them as a flat list.
      * The caller uses this list to construct a single bool/should query.
@@ -40,6 +49,10 @@ public class OrImpl extends QueryHandler implements Or {
      * vocabulary selections.
      */
     private void buildQuery(List<Filter> filters) {
+        if (filters.stream().anyMatch(OrImpl::containsElasticSetting)) {
+            throw new IllegalArgumentException("Or combine with query setting do not make sense");
+        }
+
         List<Query> queries = filters.stream()
                 .flatMap(filter -> collectQueries(filter).stream())
                 .toList();
@@ -65,8 +78,6 @@ public class OrImpl extends QueryHandler implements Or {
         }
     }
 
-    // Flatten the bool should query so that to avoid when many parameters are selected,
-    // the nested query cause Elasticsearch error
     public OrImpl(List<Filter> filters) {
         children.addAll(filters);
         buildQuery(children);

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
@@ -256,27 +256,6 @@ public class ElasticSearch extends ElasticSearchBase implements Search {
         return searchCollectionsByIds(null, Boolean.FALSE, sortBy);
     }
 
-    protected SortOptions parameterVocabsPrioritySort() {
-        return vocabPrioritySort(StacBasicField.ParameterVocabs.searchField);
-    }
-
-    protected SortOptions platformVocabsPrioritySort() {
-        return vocabPrioritySort(StacBasicField.PlatformVocabs.searchField);
-    }
-
-    protected SortOptions vocabPrioritySort(String vocabField) {
-        return SortOptions.of(so -> so
-                .script(s -> s
-                        .type(ScriptSortType.Number)
-                        .script(sc -> sc
-                                .lang("painless")
-                                .source(
-                                        "return doc.containsKey('" + vocabField + ".keyword') && " +
-                                                "!doc['" + vocabField + ".keyword'].empty ? 1 : 0;"
-                                ))
-                        .order(SortOrder.Desc)));
-    }
-
     @Override
     public ElasticSearchBase.SearchResult<StacCollectionModel> searchByParameters(List<String> keywords, String cql, List<String> properties, String sortBy, CQLCrsType coor) throws CQLException {
 
@@ -406,13 +385,13 @@ public class ElasticSearch extends ElasticSearchBase implements Search {
                 if (sortOptions == null) {
                     sortOptions = new ArrayList<>();
                 }
-                sortOptions.add(0, parameterVocabsPrioritySort());
+                sortOptions.add(0, CQLFields.parameter_vocabs.getSortBuilder().apply(SortOrder.Desc).build());
             }
             if (factory.isPlatformPrioritySort()) {
                 if (sortOptions == null) {
                     sortOptions = new ArrayList<>();
                 }
-                sortOptions.add(0, platformVocabsPrioritySort());
+                sortOptions.add(0, CQLFields.platform_vocabs.getSortBuilder().apply(SortOrder.Desc).build());
             }
 
             return searchCollectionBy(

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
@@ -257,18 +257,23 @@ public class ElasticSearch extends ElasticSearchBase implements Search {
     }
 
     protected SortOptions parameterVocabsPrioritySort(Collection<String> terms) {
-        String parameterVocabsField = StacBasicField.ParameterVocabs.searchField;
+        return vocabPrioritySort(StacBasicField.ParameterVocabs.searchField);
+    }
+
+    protected SortOptions platformVocabsPrioritySort(Collection<String> terms) {
+        return vocabPrioritySort(StacBasicField.PlatformVocabs.searchField);
+    }
+
+    protected SortOptions vocabPrioritySort(String vocabField) {
         return SortOptions.of(so -> so
                 .script(s -> s
                         .type(ScriptSortType.Number)
                         .script(sc -> sc
                                 .lang("painless")
-                                .params("terms", JsonData.of(new ArrayList<>(terms)))
-                                .source("if (!doc.containsKey('" + parameterVocabsField + ".keyword') || " +
-                                        "doc['" + parameterVocabsField + ".keyword'].empty) { return 0; } " +
-                                        "for (def value : doc['" + parameterVocabsField + ".keyword']) { " +
-                                        "if (params.terms.contains(value)) { return 1; } } " +
-                                        "return 0;"))
+                                .source(
+                                        "return doc.containsKey('" + vocabField + ".keyword') && " +
+                                                "!doc['" + vocabField + ".keyword'].empty ? 1 : 0;"
+                                ))
                         .order(SortOrder.Desc)));
     }
 
@@ -394,7 +399,7 @@ public class ElasticSearch extends ElasticSearchBase implements Search {
             }
 
             List<SortOptions> sortOptions = createSortOptions(sortBy, CQLFields.class);
-            // When the filter searches parameter_vocabs, prepend a value-aware priority sort key
+            // When the filter searches curated vocab fields, prepend value-aware priority sort keys
             // so matching human-curated records rank above AI-generated fallback records. This is
             // the first sort key; existing -score,-rank ordering is preserved within each tier.
             if (factory.isParameterPrioritySort()) {
@@ -402,6 +407,12 @@ public class ElasticSearch extends ElasticSearchBase implements Search {
                     sortOptions = new ArrayList<>();
                 }
                 sortOptions.add(0, parameterVocabsPrioritySort(factory.getParameterPrioritySortTerms()));
+            }
+            if (factory.isPlatformPrioritySort()) {
+                if (sortOptions == null) {
+                    sortOptions = new ArrayList<>();
+                }
+                sortOptions.add(0, platformVocabsPrioritySort(factory.getPlatformPrioritySortTerms()));
             }
 
             return searchCollectionBy(

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
@@ -8,8 +8,9 @@ import au.org.aodn.ogcapi.server.core.model.enumeration.*;
 import au.org.aodn.ogcapi.server.core.parser.elastic.CQLToElasticFilterFactory;
 import au.org.aodn.ogcapi.server.core.parser.elastic.QueryHandler;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.*;
 import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import co.elastic.clients.json.JsonData;
 import co.elastic.clients.elasticsearch.core.SearchMvtRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
@@ -255,6 +256,22 @@ public class ElasticSearch extends ElasticSearchBase implements Search {
         return searchCollectionsByIds(null, Boolean.FALSE, sortBy);
     }
 
+    protected SortOptions parameterVocabsPrioritySort(Collection<String> terms) {
+        String parameterVocabsField = StacBasicField.ParameterVocabs.searchField;
+        return SortOptions.of(so -> so
+                .script(s -> s
+                        .type(ScriptSortType.Number)
+                        .script(sc -> sc
+                                .lang("painless")
+                                .params("terms", JsonData.of(new ArrayList<>(terms)))
+                                .source("if (!doc.containsKey('" + parameterVocabsField + ".keyword') || " +
+                                        "doc['" + parameterVocabsField + ".keyword'].empty) { return 0; } " +
+                                        "for (def value : doc['" + parameterVocabsField + ".keyword']) { " +
+                                        "if (params.terms.contains(value)) { return 1; } } " +
+                                        "return 0;"))
+                        .order(SortOrder.Desc)));
+    }
+
     @Override
     public ElasticSearchBase.SearchResult<StacCollectionModel> searchByParameters(List<String> keywords, String cql, List<String> properties, String sortBy, CQLCrsType coor) throws CQLException {
 
@@ -376,13 +393,24 @@ public class ElasticSearch extends ElasticSearchBase implements Search {
                         .toList();
             }
 
+            List<SortOptions> sortOptions = createSortOptions(sortBy, CQLFields.class);
+            // When the filter searches parameter_vocabs, prepend a value-aware priority sort key
+            // so matching human-curated records rank above AI-generated fallback records. This is
+            // the first sort key; existing -score,-rank ordering is preserved within each tier.
+            if (factory.isParameterPrioritySort()) {
+                if (sortOptions == null) {
+                    sortOptions = new ArrayList<>();
+                }
+                sortOptions.add(0, parameterVocabsPrioritySort(factory.getParameterPrioritySortTerms()));
+            }
+
             return searchCollectionBy(
                     null,
                     should,
                     filters,
                     properties,
                     searchAfter,
-                    createSortOptions(sortBy, CQLFields.class),
+                    sortOptions,
                     score,
                     maxSize
             );

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
@@ -256,11 +256,11 @@ public class ElasticSearch extends ElasticSearchBase implements Search {
         return searchCollectionsByIds(null, Boolean.FALSE, sortBy);
     }
 
-    protected SortOptions parameterVocabsPrioritySort(Collection<String> terms) {
+    protected SortOptions parameterVocabsPrioritySort() {
         return vocabPrioritySort(StacBasicField.ParameterVocabs.searchField);
     }
 
-    protected SortOptions platformVocabsPrioritySort(Collection<String> terms) {
+    protected SortOptions platformVocabsPrioritySort() {
         return vocabPrioritySort(StacBasicField.PlatformVocabs.searchField);
     }
 
@@ -399,20 +399,20 @@ public class ElasticSearch extends ElasticSearchBase implements Search {
             }
 
             List<SortOptions> sortOptions = createSortOptions(sortBy, CQLFields.class);
-            // When the filter searches curated vocab fields, prepend value-aware priority sort keys
+            // When the filter searches curated vocab fields, prepend presence-based priority sort keys
             // so matching human-curated records rank above AI-generated fallback records. This is
             // the first sort key; existing -score,-rank ordering is preserved within each tier.
             if (factory.isParameterPrioritySort()) {
                 if (sortOptions == null) {
                     sortOptions = new ArrayList<>();
                 }
-                sortOptions.add(0, parameterVocabsPrioritySort(factory.getParameterPrioritySortTerms()));
+                sortOptions.add(0, parameterVocabsPrioritySort());
             }
             if (factory.isPlatformPrioritySort()) {
                 if (sortOptions == null) {
                     sortOptions = new ArrayList<>();
                 }
-                sortOptions.add(0, platformVocabsPrioritySort(factory.getPlatformPrioritySortTerms()));
+                sortOptions.add(0, platformVocabsPrioritySort());
             }
 
             return searchCollectionBy(

--- a/server/src/test/java/au/org/aodn/ogcapi/server/common/RestApiTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/common/RestApiTest.java
@@ -555,11 +555,11 @@ public class RestApiTest extends BaseTestClass {
                 "bf287dfe-9ce4-4969-9c59-51c39ea4d011.json"
         );
         // Make sure AND operation works
-        ResponseEntity<Collections> collections = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=score>=2 AND parameter_vocabs='wave'", Collections.class);
+        ResponseEntity<Collections> collections = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=score>=2 AND (parameter_vocabs='wave' OR ai_parameter_vocabs='wave')", Collections.class);
         assertEquals(1, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 1, only one record");
 
         // Make sure OR not work as it didn't make sense to use or with setting
-        ResponseEntity<ErrorResponse> error = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=score>=2 OR parameter_vocabs='wave'", ErrorResponse.class);
+        ResponseEntity<ErrorResponse> error = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=score>=2 OR (parameter_vocabs='wave' OR ai_parameter_vocabs='wave')", ErrorResponse.class);
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, error.getStatusCode());
         assertEquals("Or combine with query setting do not make sense", Objects.requireNonNull(error.getBody()).getMessage(), "correct error");
 
@@ -621,7 +621,7 @@ public class RestApiTest extends BaseTestClass {
 
         // Edge case on sort by with 1 item, but typo in argument sortBy, it should be sortby. Hence use API default sort -score
         // https://docs.ogc.org/DRAFTS/20-004.html#sorting-parameter-sortby
-        ResponseEntity<ExtendedCollections> collections = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=score>=2 AND parameter_vocabs='wave'&sortBy=-score,+title", ExtendedCollections.class);
+        ResponseEntity<ExtendedCollections> collections = testRestTemplate.getForEntity(getBasePath() + "/collections?filter=score>=2 AND (parameter_vocabs='wave' OR ai_parameter_vocabs='wave')&sortBy=-score,+title", ExtendedCollections.class);
         assertEquals(1, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 1, only one record");
 
         // Now return result should sort by score then title, since no query here, the score will auto adjust to 1 as all search without query default score is 1

--- a/server/src/test/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactoryTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactoryTest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CQLToElasticFilterFactoryTest {
@@ -44,33 +45,12 @@ public class CQLToElasticFilterFactoryTest {
     @Test
     public void platformVocabFilterEnablesPrioritySortAndCollectsTerms() throws CQLException {
         CQLToElasticFilterFactory<CQLFields> factory = parse(
-                "platform_vocabs='glider' OR platform_vocabs='mooring'");
+                "platform_vocabs='glider' OR ai_platform_vocabs='glider'");
 
         assertTrue(factory.isPlatformPrioritySort());
-        assertEquals(Set.of("glider", "mooring"), factory.getPlatformPrioritySortTerms());
+        assertEquals(Set.of("glider"), factory.getPlatformPrioritySortTerms());
         assertFalse(factory.isParameterPrioritySort());
         assertTrue(factory.getParameterPrioritySortTerms().isEmpty());
-    }
-
-    @Test
-    public void duplicateVocabTermsAreCollectedOnce() throws CQLException {
-        CQLToElasticFilterFactory<CQLFields> factory = parse(
-                "(parameter_vocabs='temperature' OR ai_parameter_vocabs='temperature') OR "
-                        + "(parameter_vocabs='temperature' OR ai_parameter_vocabs='temperature')");
-
-        assertEquals(Set.of("temperature"), factory.getParameterPrioritySortTerms());
-    }
-
-    @Test
-    public void aiAndUnrelatedFiltersDoNotEnablePrioritySort() throws CQLException {
-        CQLToElasticFilterFactory<CQLFields> factory = parse(
-                "ai_parameter_vocabs='temperature' OR "
-                        + "ai_platform_vocabs='glider' OR status='ongoing'");
-
-        assertFalse(factory.isParameterPrioritySort());
-        assertTrue(factory.getParameterPrioritySortTerms().isEmpty());
-        assertFalse(factory.isPlatformPrioritySort());
-        assertTrue(factory.getPlatformPrioritySortTerms().isEmpty());
     }
 
     @Test
@@ -78,13 +58,31 @@ public class CQLToElasticFilterFactoryTest {
         CQLToElasticFilterFactory<CQLFields> factory = parse(
                 "page_size=11 AND "
                         + "(parameter_vocabs='heat budget' OR ai_parameter_vocabs='heat budget') "
-                        + "AND platform_vocabs='glider'");
+                        + "AND (platform_vocabs='glider' OR ai_platform_vocabs='glider')");
 
         assertEquals("11", factory.getQuerySetting().get(CQLElasticSetting.page_size));
         assertTrue(factory.isParameterPrioritySort());
         assertEquals(Set.of("heat budget"), factory.getParameterPrioritySortTerms());
         assertTrue(factory.isPlatformPrioritySort());
         assertEquals(Set.of("glider"), factory.getPlatformPrioritySortTerms());
+    }
+
+    @Test
+    public void querySettingsCannotBeCombinedWithOr() {
+        IllegalArgumentException settingFirst = assertThrows(
+                IllegalArgumentException.class,
+                () -> parse("score>=2 OR parameter_vocabs='wave'"));
+        assertEquals(
+                "Or combine with query setting do not make sense",
+                settingFirst.getMessage());
+
+        IllegalArgumentException settingLast = assertThrows(
+                IllegalArgumentException.class,
+                () -> parse(
+                        "parameter_vocabs='wave' OR ai_parameter_vocabs='wave' OR score>=2"));
+        assertEquals(
+                "Or combine with query setting do not make sense",
+                settingLast.getMessage());
     }
 
     private CQLToElasticFilterFactory<CQLFields> parse(String cql) throws CQLException {

--- a/server/src/test/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactoryTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactoryTest.java
@@ -9,8 +9,6 @@ import org.geotools.filter.text.cql2.CQLException;
 import org.junit.jupiter.api.Test;
 import org.opengis.filter.Filter;
 
-import java.util.Set;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -20,19 +18,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class CQLToElasticFilterFactoryTest {
 
     @Test
-    public void parameterVocabFilterEnablesPrioritySortAndCollectsTerms() throws CQLException {
-        String cql = "parameter_vocabs='acoustics' OR ai_parameter_vocabs='acoustics' OR "
-                + "parameter_vocabs='aerosols' OR ai_parameter_vocabs='aerosols' OR "
-                + "parameter_vocabs='air pressure' OR ai_parameter_vocabs='air pressure'";
+    public void parameterVocabFilterEnablesPrioritySort() throws CQLException {
+        String cql = "(parameter_vocabs='acoustics' OR ai_parameter_vocabs='acoustics') OR "
+                + "(parameter_vocabs='aerosols' OR ai_parameter_vocabs='aerosols') OR "
+                + "(parameter_vocabs='air pressure' OR ai_parameter_vocabs='air pressure')";
         CQLToElasticFilterFactory<CQLFields> factory = newFactory();
         Filter filter = CompilerUtil.parseFilter(Language.ECQL, cql, factory);
 
         assertTrue(factory.isParameterPrioritySort());
-        assertEquals(
-                Set.of("acoustics", "aerosols", "air pressure"),
-                factory.getParameterPrioritySortTerms());
         assertFalse(factory.isPlatformPrioritySort());
-        assertTrue(factory.getPlatformPrioritySortTerms().isEmpty());
 
         OrImpl parameterFilter = assertInstanceOf(OrImpl.class, filter);
         assertTrue(parameterFilter.getQuery().isBool());
@@ -43,28 +37,34 @@ public class CQLToElasticFilterFactoryTest {
     }
 
     @Test
-    public void platformVocabFilterEnablesPrioritySortAndCollectsTerms() throws CQLException {
-        CQLToElasticFilterFactory<CQLFields> factory = parse(
-                "platform_vocabs='glider' OR ai_platform_vocabs='glider'");
+    public void platformVocabFilterEnablesPrioritySort() throws CQLException {
+        String cql = "(platform_vocabs='satellite' OR ai_platform_vocabs='satellite') OR "
+                + "(platform_vocabs='glider' OR ai_platform_vocabs='glider')";
+        CQLToElasticFilterFactory<CQLFields> factory = newFactory();
+        Filter filter = CompilerUtil.parseFilter(Language.ECQL, cql, factory);
 
         assertTrue(factory.isPlatformPrioritySort());
-        assertEquals(Set.of("glider"), factory.getPlatformPrioritySortTerms());
         assertFalse(factory.isParameterPrioritySort());
-        assertTrue(factory.getParameterPrioritySortTerms().isEmpty());
+
+        OrImpl platformFilter = assertInstanceOf(OrImpl.class, filter);
+        assertTrue(platformFilter.getQuery().isBool());
+        assertEquals(4, platformFilter.getQuery().bool().should().size());
+        assertTrue(
+                platformFilter.getQuery().bool().should().stream().noneMatch(query -> query.isBool()),
+                "Grouped platform vocabulary clauses should be flattened into one should list");
     }
 
     @Test
     public void prioritySortMetadataIsCollectedAlongsideQuerySettings() throws CQLException {
         CQLToElasticFilterFactory<CQLFields> factory = parse(
                 "page_size=11 AND "
-                        + "(parameter_vocabs='heat budget' OR ai_parameter_vocabs='heat budget') "
-                        + "AND (platform_vocabs='glider' OR ai_platform_vocabs='glider')");
+                        + "((parameter_vocabs='heat budget' OR ai_parameter_vocabs='heat budget')) "
+                        + "AND ((platform_vocabs='satellite' OR ai_platform_vocabs='satellite') OR "
+                        + "(platform_vocabs='glider' OR ai_platform_vocabs='glider'))");
 
         assertEquals("11", factory.getQuerySetting().get(CQLElasticSetting.page_size));
         assertTrue(factory.isParameterPrioritySort());
-        assertEquals(Set.of("heat budget"), factory.getParameterPrioritySortTerms());
         assertTrue(factory.isPlatformPrioritySort());
-        assertEquals(Set.of("glider"), factory.getPlatformPrioritySortTerms());
     }
 
     @Test

--- a/server/src/test/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactoryTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactoryTest.java
@@ -1,0 +1,99 @@
+package au.org.aodn.ogcapi.server.core.parser.elastic;
+
+import au.org.aodn.ogcapi.server.core.model.enumeration.CQLCrsType;
+import au.org.aodn.ogcapi.server.core.model.enumeration.CQLElasticSetting;
+import au.org.aodn.ogcapi.server.core.model.enumeration.CQLFields;
+import org.geotools.filter.text.commons.CompilerUtil;
+import org.geotools.filter.text.commons.Language;
+import org.geotools.filter.text.cql2.CQLException;
+import org.junit.jupiter.api.Test;
+import org.opengis.filter.Filter;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CQLToElasticFilterFactoryTest {
+
+    @Test
+    public void parameterVocabFilterEnablesPrioritySortAndCollectsTerms() throws CQLException {
+        String cql = "parameter_vocabs='acoustics' OR ai_parameter_vocabs='acoustics' OR "
+                + "parameter_vocabs='aerosols' OR ai_parameter_vocabs='aerosols' OR "
+                + "parameter_vocabs='air pressure' OR ai_parameter_vocabs='air pressure'";
+        CQLToElasticFilterFactory<CQLFields> factory = newFactory();
+        Filter filter = CompilerUtil.parseFilter(Language.ECQL, cql, factory);
+
+        assertTrue(factory.isParameterPrioritySort());
+        assertEquals(
+                Set.of("acoustics", "aerosols", "air pressure"),
+                factory.getParameterPrioritySortTerms());
+        assertFalse(factory.isPlatformPrioritySort());
+        assertTrue(factory.getPlatformPrioritySortTerms().isEmpty());
+
+        OrImpl parameterFilter = assertInstanceOf(OrImpl.class, filter);
+        assertTrue(parameterFilter.getQuery().isBool());
+        assertEquals(6, parameterFilter.getQuery().bool().should().size());
+        assertTrue(
+                parameterFilter.getQuery().bool().should().stream().noneMatch(query -> query.isBool()),
+                "Parameter vocabulary clauses should be flattened into one should list");
+    }
+
+    @Test
+    public void platformVocabFilterEnablesPrioritySortAndCollectsTerms() throws CQLException {
+        CQLToElasticFilterFactory<CQLFields> factory = parse(
+                "platform_vocabs='glider' OR platform_vocabs='mooring'");
+
+        assertTrue(factory.isPlatformPrioritySort());
+        assertEquals(Set.of("glider", "mooring"), factory.getPlatformPrioritySortTerms());
+        assertFalse(factory.isParameterPrioritySort());
+        assertTrue(factory.getParameterPrioritySortTerms().isEmpty());
+    }
+
+    @Test
+    public void duplicateVocabTermsAreCollectedOnce() throws CQLException {
+        CQLToElasticFilterFactory<CQLFields> factory = parse(
+                "(parameter_vocabs='temperature' OR ai_parameter_vocabs='temperature') OR "
+                        + "(parameter_vocabs='temperature' OR ai_parameter_vocabs='temperature')");
+
+        assertEquals(Set.of("temperature"), factory.getParameterPrioritySortTerms());
+    }
+
+    @Test
+    public void aiAndUnrelatedFiltersDoNotEnablePrioritySort() throws CQLException {
+        CQLToElasticFilterFactory<CQLFields> factory = parse(
+                "ai_parameter_vocabs='temperature' OR "
+                        + "ai_platform_vocabs='glider' OR status='ongoing'");
+
+        assertFalse(factory.isParameterPrioritySort());
+        assertTrue(factory.getParameterPrioritySortTerms().isEmpty());
+        assertFalse(factory.isPlatformPrioritySort());
+        assertTrue(factory.getPlatformPrioritySortTerms().isEmpty());
+    }
+
+    @Test
+    public void prioritySortMetadataIsCollectedAlongsideQuerySettings() throws CQLException {
+        CQLToElasticFilterFactory<CQLFields> factory = parse(
+                "page_size=11 AND "
+                        + "(parameter_vocabs='heat budget' OR ai_parameter_vocabs='heat budget') "
+                        + "AND platform_vocabs='glider'");
+
+        assertEquals("11", factory.getQuerySetting().get(CQLElasticSetting.page_size));
+        assertTrue(factory.isParameterPrioritySort());
+        assertEquals(Set.of("heat budget"), factory.getParameterPrioritySortTerms());
+        assertTrue(factory.isPlatformPrioritySort());
+        assertEquals(Set.of("glider"), factory.getPlatformPrioritySortTerms());
+    }
+
+    private CQLToElasticFilterFactory<CQLFields> parse(String cql) throws CQLException {
+        CQLToElasticFilterFactory<CQLFields> factory = newFactory();
+        CompilerUtil.parseFilter(Language.ECQL, cql, factory);
+        return factory;
+    }
+
+    private CQLToElasticFilterFactory<CQLFields> newFactory() {
+        return new CQLToElasticFilterFactory<>(CQLCrsType.EPSG4326, CQLFields.class);
+    }
+}


### PR DESCRIPTION
Prioritises matching records containing human-curated vocabulary metadata over records matched through AI-predicted vocabulary metadata (records with parameter_vocabs/platform_vocabs rank higher than records with ai:parameter_vocabs /ai:platform_vocabs)

ogc-api demo (the left side is the updated search with AI predicted parameters with reranking, the right side is the current search):
<img width="3397" height="1222" alt="image" src="https://github.com/user-attachments/assets/0052d3b5-e4ad-45c2-aae4-364ec23989b2" />

ES query request example:
```
POST /es-indexer-edge/_search?typed_keys=true {"_source":{"includes":["id"]},"query":{"bool":{"filter":[{"bool":{"filter":[{"bool":{"filter":[{"geo_bounding_box":{"summaries.proj:geometry":{"top_left":{"lat":-8.0,"lon":104.0},"bottom_right":{"lat":-43.0,"lon":163.0}}}},{"bool":{"should":[{"match_phrase":{"summaries.parameter_vocabs":{"query":"temperature"}}},{"match_phrase":{"summaries.ai:parameter_vocabs":{"query":"temperature"}}}]}}]}},{"bool":{"should":[{"match_phrase":{"summaries.platform_vocabs":{"query":"satellite"}}},{"match_phrase":{"summaries.ai:platform_vocabs":{"query":"satellite"}}},{"match_phrase":{"summaries.platform_vocabs":{"query":"glider"}}},{"match_phrase":{"summaries.ai:platform_vocabs":{"query":"glider"}}}]}}]}}],"must":[{"match_all":{}}]}},"size":800,"sort":[{"_script":{"order":"desc","script":{"source":"return doc.containsKey('summaries.platform_vocabs.keyword') && !doc['summaries.platform_vocabs.keyword'].empty ? 1 : 0;","lang":"painless"},"type":"number"}},{"_script":{"order":"desc","script":{"source":"return doc.containsKey('summaries.parameter_vocabs.keyword') && !doc['summaries.parameter_vocabs.keyword'].empty ? 1 : 0;","lang":"painless"},"type":"number"}},{"id.keyword":{"order":"asc"}}]}
```
