### PR TITLE
feature/7786-improve-search-precision

### DIFF
--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLFields.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLFields.java
@@ -174,16 +174,16 @@ public enum CQLFields implements CQLFieldsInterface {
                         null,
                         null),
         links_title_contains(
-                        StacBasicField.LinksTitle.searchField,
-                        StacBasicField.LinksTitle.displayField,
-                        (literal) -> NestedQuery.of(m -> m
-                                        .path(StacBasicField.Links.searchField)// We want the words exact so need to add space in front and end
-                                        .query(q -> q
-                                                        .match(mq -> mq
-                                                                        .field(StacBasicField.LinksTitle.searchField)
-                                                                        .query(literal))))
-                                        ._toQuery(),
-                        null),
+                StacBasicField.LinksTitle.searchField,
+                StacBasicField.LinksTitle.displayField,
+                (literal) -> NestedQuery.of(m -> m
+                                .path(StacBasicField.Links.searchField)
+                                .query(q -> q
+                                        .matchPhrase(mp -> mp
+                                                .field(StacBasicField.LinksTitle.searchField)
+                                                .query(literal))))
+                        ._toQuery(),
+                null),
         links_airole_contains(
                         StacBasicField.LinksAiRole.searchField,
                         StacBasicField.LinksAiRole.displayField,
@@ -196,12 +196,12 @@ public enum CQLFields implements CQLFieldsInterface {
                                         ._toQuery(),
                         null),
         credit_contains(
-                        StacSummeries.Credits.searchField,
-                        StacSummeries.Credits.displayField,
-                        (literal) -> MatchQuery.of(m -> m// We want the words exact so need to add space in front and end
-                                        .field(StacSummeries.Credits.searchField)
-                                        .query(literal))._toQuery(),
-                        null),
+                StacSummeries.Credits.searchField,
+                StacSummeries.Credits.displayField,
+                (literal) -> MatchPhraseQuery.of(m -> m
+                        .field(StacSummeries.Credits.searchField)
+                        .query(literal))._toQuery(),
+                null),
         status(
                         StacSummeries.Status.searchField,
                         StacSummeries.Status.displayField,

--- a/server/src/test/java/au/org/aodn/ogcapi/server/common/RestApiTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/common/RestApiTest.java
@@ -565,7 +565,7 @@ public class RestApiTest extends BaseTestClass {
 
         // Lower score but the fuzzy is now with operator AND, therefore it will try to match all words 'dataset' and 'includes' with fuzzy
         collections = testRestTemplate.getForEntity(getBasePath() + "/collections?q='dataset includes'&filter=score>=1", Collections.class);
-        assertEquals(3, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 1, with score 3");
+        assertEquals(1, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 1, with score 3");
         assertEquals("bf287dfe-9ce4-4969-9c59-51c39ea4d011", Objects.requireNonNull(collections.getBody()).getCollections().get(0).getId(), "bf287dfe-9ce4-4969-9c59-51c39ea4d011");
 
         // Increase score will drop two record


### PR DESCRIPTION
Change `links.title` and `summaries.credits` free-text clauses from `match` to `match_phrase`.

These fields previously used `match`, which defaults to OR operator. For long search text such as:
`imos - satellite remote sensing - sst - l3s - multi sensor - 1 month - night time - australia`

a record could score if `links.title` or `summaries.credits` contained any individual term. This produced many irrelevant results, including more than 5000 matches in the example above.
<img width="1699" height="635" alt="image" src="https://github.com/user-attachments/assets/aa3f4984-0060-4c64-a5b0-1fbeff0c3875" />

With `match_phrase`, these fields now only contribute when the terms appear as the same phrase, in order. This makes long-title searches more precise while leaving the other search fields unchanged.
<img width="1697" height="631" alt="image" src="https://github.com/user-attachments/assets/67268d46-1475-4a21-b8ea-3ff47057c81d" />
