### PR TITLE
change duringImpl logic to adapt overlapped date range

### DIFF
--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLFields.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLFields.java
@@ -187,7 +187,7 @@ public enum CQLFields implements CQLFieldsInterface {
         credit_contains(
                         StacSummeries.Credits.searchField,
                         StacSummeries.Credits.displayField,
-                        (literal) -> MatchQuery.of(m -> m// We want the words exact so need to add space in front and end
+                        (literal) -> MatchPhraseQuery.of(m -> m// We want the words exact so need to add space in front and end
                                         .field(StacSummeries.Credits.searchField)
                                         .query(literal))._toQuery(),
                         null),

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/DuringImpl.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/parser/elastic/DuringImpl.java
@@ -4,6 +4,7 @@ import au.org.aodn.ogcapi.server.core.model.enumeration.CQLFields;
 import au.org.aodn.ogcapi.server.core.model.enumeration.CQLFieldsInterface;
 import au.org.aodn.ogcapi.server.core.model.enumeration.StacSummeries;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.ExistsQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.NestedQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
@@ -67,15 +68,23 @@ public class DuringImpl<T extends Enum<T> & CQLFieldsInterface> extends QueryHan
                 if(type instanceof CQLFields cqlFields
                         && cqlFields == CQLFields.temporal) {
 
-                    Query gte = RangeQuery.of(r -> r
+                    Query endAfterOrAtFilterStart = RangeQuery.of(r -> r
                             .date(d -> d
-                                    .field(StacSummeries.TemporalStart.searchField)
+                                    .field(StacSummeries.TemporalEnd.searchField)
                                     .gte(dateFormatter.format(period.getBeginning().getPosition().getDate()))
                                     .format("strict_date_optional_time")))._toQuery();
 
-                    Query lte = RangeQuery.of(r -> r
+                    Query missingEndDate = BoolQuery.of(b -> b
+                            .mustNot(ExistsQuery.of(e -> e
+                                    .field(StacSummeries.TemporalEnd.searchField))._toQuery()))._toQuery();
+
+                    Query endAfterFilterStartOrOngoing = BoolQuery.of(b -> b
+                            .should(endAfterOrAtFilterStart, missingEndDate)
+                            .minimumShouldMatch("1"))._toQuery();
+
+                    Query startBeforeOrAtFilterEnd = RangeQuery.of(r -> r
                             .date(d -> d
-                                    .field(StacSummeries.TemporalEnd.searchField)
+                                    .field(StacSummeries.TemporalStart.searchField)
                                     .lte(dateFormatter.format(period.getEnding().getPosition().getDate()))
                                     .format("strict_date_optional_time")))._toQuery();
 
@@ -83,7 +92,7 @@ public class DuringImpl<T extends Enum<T> & CQLFieldsInterface> extends QueryHan
                     this.query = NestedQuery.of(n -> n
                             .path(StacSummeries.Temporal.searchField)
                             .query(BoolQuery.of(q -> q
-                                    .must(gte, lte))._toQuery()
+                                    .must(endAfterFilterStartOrOngoing, startBeforeOrAtFilterEnd))._toQuery()
                             )
                     )._toQuery();
                 }

--- a/server/src/test/java/au/org/aodn/ogcapi/server/common/RestApiTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/common/RestApiTest.java
@@ -267,8 +267,8 @@ public class RestApiTest extends BaseTestClass {
                 collections.getBody().getCollections().get(0).getId(),
                 "Correct UUID - caf7220a-19e0-4a7f-9af6-eade6c79a47a");
 
-        // The start datetime is 1 sec more then one of the start date in the record, however it still fit into the next start/end slot, so should return same result
-        collections = testRestTemplate.getForEntity(getBasePath() + "/collections?datetime=1991-12-31T13:00:01Z/2013-06-16T14:00:00Z", Collections.class);
+        // The query start time is the first end , the queried time range should overlap the next start/end slot, so should return same result
+        collections = testRestTemplate.getForEntity(getBasePath() + "/collections?datetime=1995-01-30T13:00:00Z/2013-06-16T14:00:00Z", Collections.class);
         // There are only 3 docs
         assertEquals(1, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 1, this record have 2 start/end");
         assertEquals(

--- a/server/src/test/java/au/org/aodn/ogcapi/server/common/RestApiTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/common/RestApiTest.java
@@ -239,7 +239,8 @@ public class RestApiTest extends BaseTestClass {
         // The time is slight off by 1 sec so only 1 document returned
         collections = testRestTemplate.getForEntity(getBasePath() + "/collections?datetime=1870-07-16T14:10:45Z/2013-06-16T14:00:00Z", Collections.class);
         // There are only 3 docs
-        assertEquals(1, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 1");
+        // matched records: 7709f541-fc0c-4318-b5b9-9053aa474e0e and 5c418118-2581-4936-b6fd-d6bedfe74f62
+        assertEquals(2, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 2");
         assertEquals(
                 "5c418118-2581-4936-b6fd-d6bedfe74f62",
                 collections.getBody().getCollections().get(0).getId(),
@@ -254,7 +255,7 @@ public class RestApiTest extends BaseTestClass {
     public void verifyDateTimeBoundsWithDiscreteTime() throws IOException {
         super.insertJsonToElasticRecordIndex(
                 "516811d7-cd1e-207a-e0440003ba8c79dd.json",
-                "7709f541-fc0c-4318-b5b9-9053aa474e0e.json",
+                "5c418118-2581-4936-b6fd-d6bedfe74f62.json",
                 "caf7220a-19e0-4a7f-9af6-eade6c79a47a.json"     // This one have two start/end
         );
 

--- a/server/src/test/java/au/org/aodn/ogcapi/server/common/RestApiTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/common/RestApiTest.java
@@ -267,7 +267,7 @@ public class RestApiTest extends BaseTestClass {
                 collections.getBody().getCollections().get(0).getId(),
                 "Correct UUID - caf7220a-19e0-4a7f-9af6-eade6c79a47a");
 
-        // The query start time is the first end , the queried time range should overlap the next start/end slot, so should return same result
+        // The query start time is the first end, the queried time range should overlap the next start/end slot, so should return same result
         collections = testRestTemplate.getForEntity(getBasePath() + "/collections?datetime=1995-01-30T13:00:00Z/2013-06-16T14:00:00Z", Collections.class);
         // There are only 3 docs
         assertEquals(1, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 1, this record have 2 start/end");
@@ -277,13 +277,13 @@ public class RestApiTest extends BaseTestClass {
                 "Correct UUID - caf7220a-19e0-4a7f-9af6-eade6c79a47a");
 
         // Now we check the before which should include the same record as it match one of the start/end time
-        collections = testRestTemplate.getForEntity(getBasePath() + "/collections?datetime=/1995-03-30T13:00:00Z", Collections.class);
+        collections = testRestTemplate.getForEntity(getBasePath() + "/collections?datetime=/1994-02-21T13:00:00Z", Collections.class);
         // There are only 3 docs
-        assertEquals(1, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 1, this record have 2 start/end");
+        assertEquals(1, Objects.requireNonNull(collections.getBody()).getCollections().size(), "hit 1");
         assertEquals(
-                "caf7220a-19e0-4a7f-9af6-eade6c79a47a",
+                "5c418118-2581-4936-b6fd-d6bedfe74f62",
                 collections.getBody().getCollections().get(0).getId(),
-                "Correct UUID - caf7220a-19e0-4a7f-9af6-eade6c79a47a");
+                "Correct UUID - 5c418118-2581-4936-b6fd-d6bedfe74f62");
 
         collections = testRestTemplate.getForEntity(getBasePath() + "/collections?datetime=/2013-06-16T14:00:00Z", Collections.class);
         // There are only 3 docs

--- a/server/src/test/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactoryTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/core/parser/elastic/CQLToElasticFilterFactoryTest.java
@@ -3,11 +3,15 @@ package au.org.aodn.ogcapi.server.core.parser.elastic;
 import au.org.aodn.ogcapi.server.core.model.enumeration.CQLCrsType;
 import au.org.aodn.ogcapi.server.core.model.enumeration.CQLElasticSetting;
 import au.org.aodn.ogcapi.server.core.model.enumeration.CQLFields;
+import au.org.aodn.ogcapi.server.core.model.enumeration.StacSummeries;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import org.geotools.filter.text.commons.CompilerUtil;
 import org.geotools.filter.text.commons.Language;
 import org.geotools.filter.text.cql2.CQLException;
 import org.junit.jupiter.api.Test;
 import org.opengis.filter.Filter;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -68,6 +72,41 @@ public class CQLToElasticFilterFactoryTest {
     }
 
     @Test
+    public void temporalDuringUsesOverlapRangeQueryAndIncludesOngoingRecords() throws CQLException {
+        Filter filter = CompilerUtil.parseFilter(
+                Language.ECQL,
+                "temporal DURING 2025-06-25T00:00:00Z/2026-06-25T00:00:00Z",
+                newFactory());
+
+        DuringImpl<?> duringFilter = assertInstanceOf(DuringImpl.class, filter);
+        assertTrue(duringFilter.getQuery().isNested());
+
+        List<Query> must = duringFilter.getQuery().nested().query().bool().must();
+        assertEquals(2, must.size());
+
+        Query startRange = findDateRange(must, StacSummeries.TemporalStart.searchField);
+        assertEquals("strict_date_optional_time", startRange.range().date().format());
+        assertTrue(startRange.range().date().lte().contains("2026-06-25"));
+
+        Query endAfterFilterStartOrOngoing = must.stream()
+                .filter(Query::isBool)
+                .findFirst()
+                .orElseThrow();
+        assertEquals("1", endAfterFilterStartOrOngoing.bool().minimumShouldMatch());
+
+        List<Query> should = endAfterFilterStartOrOngoing.bool().should();
+        Query endRange = findDateRange(should, StacSummeries.TemporalEnd.searchField);
+        assertEquals("strict_date_optional_time", endRange.range().date().format());
+        assertTrue(endRange.range().date().gte().contains("2025-06-25"));
+
+        assertTrue(should.stream()
+                .filter(Query::isBool)
+                .flatMap(query -> query.bool().mustNot().stream())
+                .anyMatch(query -> query.isExists()
+                        && StacSummeries.TemporalEnd.searchField.equals(query.exists().field())));
+    }
+
+    @Test
     public void querySettingsCannotBeCombinedWithOr() {
         IllegalArgumentException settingFirst = assertThrows(
                 IllegalArgumentException.class,
@@ -93,5 +132,14 @@ public class CQLToElasticFilterFactoryTest {
 
     private CQLToElasticFilterFactory<CQLFields> newFactory() {
         return new CQLToElasticFilterFactory<>(CQLCrsType.EPSG4326, CQLFields.class);
+    }
+
+    private Query findDateRange(List<Query> queries, String field) {
+        return queries.stream()
+                .filter(Query::isRange)
+                .filter(query -> query.range().isDate())
+                .filter(query -> field.equals(query.range().date().field()))
+                .findFirst()
+                .orElseThrow();
     }
 }


### PR DESCRIPTION
This PR fixes temporal DURING filtering so collection date ranges are matched by overlap rather than by requiring the record start/end to sit inside the query bounds.

**Changes**
- Updates DuringImpl to match records where temporal.start <= filterEnd and temporal.end >= filterStart.
- Includes ongoing records with no temporal.end when their start date overlaps the requested range.
- Updates REST API datetime tests to reflect the corrected range-overlap behaviour.
- Changes credit_contains from a match query to a match_phrase query for more precise credit field matching.

<img width="1670" height="629" alt="image" src="https://github.com/user-attachments/assets/8dcb688c-daae-4068-9ef7-c03f5da2f795" />
