### PR TITLE
Bugfix/7736 fix no data email sent bug

### DIFF
--- a/server/src/main/java/au/org/aodn/ogcapi/server/processes/RestApi.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/processes/RestApi.java
@@ -65,10 +65,13 @@ public class RestApi implements ProcessesApi {
                 String outputFormat = DatasetDownloadEnums.Parameter.OUTPUT_FORMAT.getStringInput(body);
                 Object multiPolygon = DatasetDownloadEnums.Parameter.MULTI_POLYGON.getObjectInput(body);
 
-                // move the notify user email from data-access-service to here to make the first email faster
-                restServices.notifyUser(recipient, uuid, startDate, endDate, multiPolygon, collectionTitle, fullMetadataLink, suggestedCitation);
-
                 var response = restServices.downloadData(uuid, key, startDate, endDate, multiPolygon, recipient, collectionTitle, fullMetadataLink, suggestedCitation, outputFormat);
+
+                // The notify user email lives here rather than in data-access-service to make the first
+                // email faster
+                // It must only be sent once AWS Batch has accepted the job and returned
+                // a job id, otherwise we promise the user a file that will never be produced.
+                restServices.notifyUser(recipient, uuid, startDate, endDate, multiPolygon, collectionTitle, fullMetadataLink, suggestedCitation);
 
                 var value = new InlineValue(response.getBody());
                 var status = new InlineValue(Integer.toString(HttpStatus.OK.value()));

--- a/server/src/main/java/au/org/aodn/ogcapi/server/processes/RestServices.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/processes/RestServices.java
@@ -74,7 +74,9 @@ public class RestServices {
 
             ses.sendEmail(request);
 
-        } catch (SesException e) {
+        } catch (Exception e) {
+            // Best effort: this runs after the batch job was accepted, so a failure to notify
+            // must not surface as a failed download request for a job that is already running.
             log.error("Error sending email: {}", e.getMessage());
         }
     }
@@ -136,7 +138,14 @@ public class RestServices {
                 .build();
 
         SubmitJobResponse submitJobResponse = batchClient.submitJob(submitJobRequest);
-        return submitJobResponse.jobId();
+        String jobId = submitJobResponse.jobId();
+
+        // Callers treat a returned job id as proof the job was accepted (the user gets a
+        // "processing started" email off the back of it), so never hand back a blank one.
+        if (jobId == null || jobId.isBlank()) {
+            throw new IllegalStateException("AWS Batch did not return a job id for job '" + jobName + "'");
+        }
+        return jobId;
     }
 
     private String generateStartedEmailContent(

--- a/server/src/test/java/au/org/aodn/ogcapi/server/processes/RestApiTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/processes/RestApiTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -22,6 +23,9 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,6 +65,11 @@ public class RestApiTest {
         assert results != null;
         InlineValue message = (InlineValue) results.get("message");
         assertEquals("Job submitted with ID: test-job-id", message.message());
+
+        // The "processing started" email must go out only after AWS Batch returned a job id
+        InOrder inOrder = inOrder(restServices);
+        inOrder.verify(restServices).downloadData(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+        inOrder.verify(restServices).notifyUser(any(), any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -75,6 +84,9 @@ public class RestApiTest {
         assert results != null;
         InlineValue error = (InlineValue) results.get(InlineResponseKeyEnum.MESSAGE.getValue());
         assertEquals("Error while getting dataset", error.message());
+
+        // No job was submitted, so the user must not be told their data is being processed
+        verify(restServices, never()).notifyUser(any(), any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test

--- a/server/src/test/java/au/org/aodn/ogcapi/server/processes/RestServicesTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/processes/RestServicesTest.java
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.batch.model.SubmitJobRequest;
 import software.amazon.awssdk.services.batch.model.SubmitJobResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -115,5 +116,17 @@ public class RestServicesTest {
         String suggestedKey = DatasetDownloadEnums.Parameter.SUGGESTED_CITATION.getValue();
         assertEquals("unavailable", captured.parameters().get(suggestedKey));
         assertEquals(ResponseEntity.ok("Job submitted with ID: " + jobId), response);
+    }
+
+    @Test
+    public void submitJobWithoutJobIdThrows() {
+        // AWS Batch answered but gave us no job id, so the job was never really queued.
+        // This must fail loudly: the caller sends the "processing started" email off the
+        // back of a successful downloadData().
+        when(batchClient.submitJob(any(SubmitJobRequest.class))).thenReturn(SubmitJobResponse.builder().build());
+
+        assertThrows(IllegalStateException.class, () -> restServices.downloadData(
+                "test-uuid", "test-dname", "2023-01-01", "2023-01-31", "non-specified", "test@example.com",
+                "Test Ocean Data Collection", "https://metadata.imas.utas.edu.au/.../test-uuid-123", "", "geotiff"));
     }
 }


### PR DESCRIPTION
### Bug investigation
When the frontend calls the download endpoint, we sent the "we've started processing your data" email **before** submitting the AWS Batch job:  
```                                                                                                    
restServices.notifyUser(...);      // email goes out                                                            
restServices.downloadData(...);    // job gets submitted (can fail here)                                        
```                                                                                           
If the submit failed — bad parameters, AWS Batch rejects the job, no job id came back — the user had already been told their file was on the way.

### Fix
**1. Submit first, email second** (`RestApi.java`) 
```                                                                                                        
var response = restServices.downloadData(...);   // job must be accepted first                                  
restServices.notifyUser(...);                    // only then tell the user                                     
```                                                                                                             
**2. Treat a missing job id as a failure** (`RestServices.submitJob`)                                           
AWS Batch returning no job id now throws instead of quietly producing `"Job submitted with ID: null"`. No job id means no job, so no email.                                                                                                                  
