### PR TITLE
fix: classify email geometry by shape so triangles render as polygon …

### DIFF
--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/util/EmailUtils.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/util/EmailUtils.java
@@ -12,8 +12,10 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Utility for email-related operations
@@ -107,7 +109,7 @@ public class EmailUtils {
     }
 
     /**
-     * Generate HTML for bounding box selections only (rectangles with 4 or fewer unique vertices).
+     * Generate HTML for bounding box selections only (axis-aligned rectangles).
      * Freeform polygons are handled separately by {@link #generatePolygonHtml}.
      *
      * @param multipolygon - the multipolygon object
@@ -133,7 +135,7 @@ public class EmailUtils {
                 List<List<BigDecimal>> uniqueVertices = removeClosingPoint(ring);
 
                 // Skip freeform polygons, those are handled by generatePolygonHtml
-                if (uniqueVertices.size() > 4) {
+                if (!isAxisAlignedRectangle(uniqueVertices)) {
                     continue;
                 }
 
@@ -183,7 +185,7 @@ public class EmailUtils {
     }
 
     /**
-     * Generate HTML for freeform polygon selections (more than 4 unique vertices).
+     * Generate HTML for freeform polygon selections (any shape that is not an axis-aligned rectangle).
      * Bounding boxes are handled separately by {@link #generateBboxHtml}.
      *
      * @param multipolygon - the multipolygon object
@@ -209,7 +211,7 @@ public class EmailUtils {
                 List<List<BigDecimal>> uniqueVertices = removeClosingPoint(ring);
 
                 // Skip bounding boxes, those are handled by generateBboxHtml
-                if (uniqueVertices.size() <= 4) {
+                if (isAxisAlignedRectangle(uniqueVertices)) {
                     continue;
                 }
 
@@ -236,6 +238,35 @@ public class EmailUtils {
      */
     protected static String formatCoordinate(double value) {
         return BigDecimal.valueOf(value).setScale(5, RoundingMode.HALF_UP).toPlainString();
+    }
+
+    /**
+     * True when the ring is exactly the axis-aligned rectangle of its own bounding box.
+     * Vertices may carry an elevation (a 3rd value); only lon/lat are compared.
+     *
+     * @param uniqueVertices - the ring's vertices with the closing point already removed
+     * @return true if the vertices form an axis-aligned rectangle
+     */
+    protected static boolean isAxisAlignedRectangle(List<List<BigDecimal>> uniqueVertices) {
+        Set<List<BigDecimal>> uniqueCorners = new HashSet<>();
+        Set<BigDecimal> uniqueLons = new HashSet<>();
+        Set<BigDecimal> uniqueLats = new HashSet<>();
+
+        for (List<BigDecimal> point : uniqueVertices) {
+            if (point.size() < 2) {
+                return false;
+            }
+            // stripTrailingZeros so 145.0 and 145.00 compare as the same value
+            BigDecimal lon = point.get(0).stripTrailingZeros();
+            BigDecimal lat = point.get(1).stripTrailingZeros();
+            uniqueCorners.add(List.of(lon, lat));
+            uniqueLons.add(lon);
+            uniqueLats.add(lat);
+        }
+
+        // 4 distinct corners drawn from only 2 longitudes x 2 latitudes can only
+        // be the min/max corner combinations of a rectangle.
+        return uniqueCorners.size() == 4 && uniqueLons.size() == 2 && uniqueLats.size() == 2;
     }
 
     /**

--- a/server/src/test/java/au/org/aodn/ogcapi/server/core/util/EmailUtilsTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/core/util/EmailUtilsTest.java
@@ -467,4 +467,61 @@ public class EmailUtilsTest {
         assertTrue(result.contains("Bounding Box"));
         assertFalse(result.contains("Polygon Selection"));
     }
+
+    /**
+     * Test that a triangle (3 vertices) shows the polygon section, not a bbox
+     */
+    @Test
+    void testTriangleShowsPolygonSection() {
+        Map<String, Object> triangle = Map.of(
+                "type", "MultiPolygon",
+                "coordinates", List.of(
+                        List.of(
+                                List.of(
+                                        List.of(145.0, -40.0),
+                                        List.of(146.0, -41.0),
+                                        List.of(144.5, -41.5),
+                                        List.of(145.0, -40.0)
+                                )
+                        )
+                )
+        );
+
+        String result = EmailUtils.generateSubsettingSection(
+                "non-specified", "non-specified", triangle, new ObjectMapper()
+        );
+
+        assertTrue(result.contains("Polygon Selection"));
+        assertTrue(result.contains("Point 3: (-41.50000, 144.50000)"));
+        assertFalse(result.contains("Bounding Box"));
+    }
+
+    /**
+     * Test that a non-rectangular quadrilateral (4 vertices) shows the polygon section, not a bbox
+     */
+    @Test
+    void testNonRectangularQuadShowsPolygonSection() {
+        Map<String, Object> quad = Map.of(
+                "type", "MultiPolygon",
+                "coordinates", List.of(
+                        List.of(
+                                List.of(
+                                        List.of(145.0, -40.0),
+                                        List.of(146.2, -40.3),
+                                        List.of(146.0, -41.5),
+                                        List.of(144.8, -41.0),
+                                        List.of(145.0, -40.0)
+                                )
+                        )
+                )
+        );
+
+        String result = EmailUtils.generateSubsettingSection(
+                "non-specified", "non-specified", quad, new ObjectMapper()
+        );
+
+        assertTrue(result.contains("Polygon Selection"));
+        assertTrue(result.contains("Point 4: (-41.00000, 144.80000)"));
+        assertFalse(result.contains("Bounding Box"));
+    }
 }


### PR DESCRIPTION
<img width="772" height="414" alt="Screenshot from 2026-07-29 11-20-34" src="https://github.com/user-attachments/assets/cbc2acf9-2bbc-4e6e-a14b-40555fae0d66" />