### PR TITLE
Feature/8876 improve ranking for partner organisation

### DIFF
--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLFields.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLFields.java
@@ -10,6 +10,9 @@ import java.io.StringReader;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.stream.Stream;
 
 /**
  * We do not want to expose the internal field to outsider, the CQL field in the
@@ -27,17 +30,11 @@ public enum CQLFields implements CQLFieldsInterface {
                         null,
                         null),
         dataset_group(
-                        StacSummeries.DatasetGroup.searchField,
-                        StacSummeries.DatasetGroup.displayField,
-                        (literal) -> TermsQuery.of(t -> t
-                                .field(StacSummeries.DatasetGroup.searchField)
-                                .terms(tf -> tf.value(List.of(
-                                        FieldValue.of(literal.toLowerCase().trim()))))
-                                // this boost should be higher than the title boost, cause in some cases, the title contains
-                                // organisation name but the record is not from that organisation (example: aims, csiro)
-                                .boost(100.0F))
-                                ._toQuery(),
-                        null),
+                StacSummeries.DatasetGroup.searchField,
+                StacSummeries.DatasetGroup.displayField,
+                literal -> datasetGroupTermsQuery(List.of(
+                        normalizeDatasetGroupTerm(literal))),
+                null),
         update_frequency(
                         StacSummeries.UpdateFrequency.searchField,
                         StacSummeries.UpdateFrequency.displayField,
@@ -332,6 +329,49 @@ public enum CQLFields implements CQLFieldsInterface {
                                                 .source("return doc.containsKey('" + vocabField + ".keyword') && "
                                                                 + "!doc['" + vocabField + ".keyword'].empty ? 1 : 0;"))
                                 .order(order));
+        }
+
+        private static String normalizeDatasetGroupTerm(String value) {
+                return value.toLowerCase(Locale.ROOT).trim();
+        }
+
+        private static Query datasetGroupTermsQuery(List<String> values) {
+                List<FieldValue> terms = values.stream()
+                        .filter(value -> !value.isBlank())
+                        .distinct()
+                        .map(FieldValue::of)
+                        .toList();
+
+                return TermsQuery.of(query -> query
+                                .field(StacSummeries.DatasetGroup.searchField)
+                                .terms(field -> field.value(terms))
+                                .boost(100.0F))
+                        ._toQuery();
+        }
+
+        /**
+         * Builds a dataset-group query specifically for free-text search.
+         * Unquoted input includes both the complete normalized input and its
+         * individual words. For example, "csiro temperature" produces
+         * ["csiro temperature", "csiro", "temperature"].
+         *
+         * Double-quoted free-text input is treated as one exact value.
+         * Dataset-group CQL filters continue to use getPropertyEqualToQuery().
+         */
+        public static Query getDatasetGroupTextSearchQuery(
+                String literal,
+                boolean isExact) {
+
+                String normalized = normalizeDatasetGroupTerm(literal);
+
+                List<String> candidates = isExact
+                        ? List.of(normalized)
+                        : Stream.concat(
+                                Stream.of(normalized),
+                                Arrays.stream(normalized.split("\\s+")))
+                        .toList();
+
+                return datasetGroupTermsQuery(candidates);
         }
 
         @Override

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLFields.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLFields.java
@@ -29,9 +29,14 @@ public enum CQLFields implements CQLFieldsInterface {
         dataset_group(
                         StacSummeries.DatasetGroup.searchField,
                         StacSummeries.DatasetGroup.displayField,
-                        (literal) -> TermsQuery.of(t -> t.field(StacSummeries.DatasetGroup.searchField)
-                                        .terms(tf -> tf.value(List.of(FieldValue.of(literal.toLowerCase().trim())))))
-                                        ._toQuery(),
+                        (literal) -> TermsQuery.of(t -> t
+                                .field(StacSummeries.DatasetGroup.searchField)
+                                .terms(tf -> tf.value(List.of(
+                                        FieldValue.of(literal.toLowerCase().trim()))))
+                                // this boost should be higher than the title boost, cause in some cases, the title contains
+                                // organisation name but the record is not from that organisation (example: aims, csiro)
+                                .boost(100.0F))
+                                ._toQuery(),
                         null),
         update_frequency(
                         StacSummeries.UpdateFrequency.searchField,

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLFields.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/model/enumeration/CQLFields.java
@@ -351,10 +351,8 @@ public enum CQLFields implements CQLFieldsInterface {
 
         /**
          * Builds a dataset-group query specifically for free-text search.
-         * Unquoted input includes both the complete normalized input and its
-         * individual words. For example, "csiro temperature" produces
-         * ["csiro temperature", "csiro", "temperature"].
-         *
+         * Unquoted input includes both the complete normalized input and its individual words.
+         * For example, "csiro temperature" => ["csiro temperature", "csiro", "temperature"].
          * Double-quoted free-text input is treated as one exact value.
          * Dataset-group CQL filters continue to use getPropertyEqualToQuery().
          */

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
@@ -417,6 +417,8 @@ public class ElasticSearch extends ElasticSearchBase implements Search {
                     should.add(CQLFields.acronym_desc.getPropertyEqualToQuery(term));
                     // credit_contains uses match query by default, exact match is not applied here
                     should.add(CQLFields.credit_contains.getPropertyEqualToQuery(term));
+                    // match the acronym for AODN partner organisations
+                    should.add(CQLFields.dataset_group.getPropertyEqualToQuery(term));
                 }
             }
 

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearch.java
@@ -311,6 +311,8 @@ public class ElasticSearch extends ElasticSearchBase implements Search {
                 should.add(CQLFields.acronym_desc.getPropertyEqualToQuery(term));
                 // credit_contains uses match query by default, exact match is not applied here
                 should.add(CQLFields.credit_contains.getPropertyEqualToQuery(term));
+                // match the acronym for AODN partner organisations
+                should.add(CQLFields.getDatasetGroupTextSearchQuery(term, isExact));
             }
         }
 
@@ -418,7 +420,7 @@ public class ElasticSearch extends ElasticSearchBase implements Search {
                     // credit_contains uses match query by default, exact match is not applied here
                     should.add(CQLFields.credit_contains.getPropertyEqualToQuery(term));
                     // match the acronym for AODN partner organisations
-                    should.add(CQLFields.dataset_group.getPropertyEqualToQuery(term));
+                    should.add(CQLFields.getDatasetGroupTextSearchQuery(term, isExact));
                 }
             }
 

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearchBase.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/service/ElasticSearchBase.java
@@ -402,7 +402,8 @@ public abstract class ElasticSearchBase {
         SearchResponse<ObjectNode> response = esClient.search(request, ObjectNode.class);
 
         if (simplified) {
-            return mapper.valueToTree(ExplainSimplifier.from(response));
+            // keep the request which carries the exact values of every terms clause
+            return mapper.valueToTree(ExplainSimplifier.from(response, toJsonNode(request)));
         }
 
         ObjectNode result = mapper.createObjectNode();

--- a/server/src/main/java/au/org/aodn/ogcapi/server/core/util/ExplainSimplifier.java
+++ b/server/src/main/java/au/org/aodn/ogcapi/server/core/util/ExplainSimplifier.java
@@ -13,7 +13,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -29,6 +31,17 @@ public class ExplainSimplifier {
      */
     protected static final Pattern WEIGHT_PATTERN = Pattern.compile("^weight\\((.*) in \\d+\\)");
 
+    /**
+     * A terms set leaf. E.g.  "summaries.dataset_group:(csiro csiro temperature temperature)^100.0"
+     */
+    protected static final Pattern TERMS_SET_PATTERN =
+            Pattern.compile("^([^\\s:()]+):\\((.*)\\)(?:\\^([\\d.eE+-]+))?$");
+
+    protected static final String TERMS_CLAUSE = "terms";
+
+    /** A run two different clauses could have produced, so it cannot be separated safely */
+    protected static final String AMBIGUOUS = "";
+
     protected static final String WEIGHT_PREFIX = "weight(";
 
     protected static final String SYNONYM_PREFIX = "Synonym(";
@@ -41,6 +54,31 @@ public class ExplainSimplifier {
                     Comparator.reverseOrder());
 
     private ExplainSimplifier() {
+    }
+
+    /**
+     * Lucene joins the values of a terms query with a space, "field:(a b c)", and a value can
+     * itself hold a space, e.g. "csiro oceans and atmosphere", so the rendered run cannot be
+     * split on its own. The request still holds the exact values, so pair every rendered leaf
+     * back with the clause that produced it and re-join those values with a comma.
+     *
+     * @param request the search request that produced the response, serialised
+     */
+    public static ExplainSimplifiedResponse from(SearchResponse<ObjectNode> response, JsonNode request) {
+        ExplainSimplifiedResponse simplified = from(response);
+        Map<String, String> byRendering = termsClausesOf(request);
+
+        if (byRendering.isEmpty()) {
+            return simplified;
+        }
+
+        for (ExplainSimplifiedResponse.Hit hit : simplified.getHits()) {
+            for (ExplainSimplifiedResponse.MatchedFilter filter : hit.getFilters()) {
+                filter.setDescription(separateTermsValues(filter.getDescription(), byRendering));
+            }
+        }
+
+        return simplified;
     }
 
     public static ExplainSimplifiedResponse from(SearchResponse<ObjectNode> response) {
@@ -183,6 +221,78 @@ public class ExplainSimplifier {
 
             collectScoreParts(detail.details(), terms, filters);
         }
+    }
+
+    protected static Map<String, String> termsClausesOf(JsonNode request) {
+        Map<String, String> byRendering = new HashMap<>();
+        collectTermsClauses(request, byRendering);
+        return byRendering;
+    }
+
+    protected static void collectTermsClauses(JsonNode node, Map<String, String> byRendering) {
+        if (node == null || node.isValueNode()) {
+            return;
+        }
+
+        JsonNode terms = node.get(TERMS_CLAUSE);
+        if (terms != null && terms.isObject()) {
+            // one field per clause, the other properties are the query options, e.g. "boost"
+            terms.forEach(values -> indexTermsClause(values, byRendering));
+        }
+
+        // an object iterates over its values, an array over its elements
+        node.forEach(child -> collectTermsClauses(child, byRendering));
+    }
+
+    protected static void indexTermsClause(JsonNode values, Map<String, String> byRendering) {
+        if (!values.isArray() || values.isEmpty()) {
+            return;
+        }
+
+        List<String> written = new ArrayList<>();
+
+        for (JsonNode value : values) {
+            if (!value.isTextual()) {
+                // a numeric value or a terms lookup does not render as a run of words
+                return;
+            }
+            written.add(value.asText());
+        }
+
+        index(written.stream().sorted().toList(), byRendering);
+        index(written, byRendering);
+    }
+
+    protected static void index(List<String> values, Map<String, String> byRendering) {
+        byRendering.merge(
+                String.join(" ", values),
+                String.join(",", values),
+                (existing, added) -> existing.equals(added) ? existing : AMBIGUOUS);
+    }
+
+    /**
+     * Report a terms set leaf with its values separated, keeping the compiled lucene shape, e.g.
+     *   summaries.dataset_group:(csiro csiro temperature temperature)^100.0
+     * becomes
+     *   summaries.dataset_group:(csiro,csiro temperature,temperature)^100.0
+     * Any other description, e.g. a bbox filter or the match_all, is passed through untouche.
+     */
+    protected static String separateTermsValues(String description, Map<String, String> byRendering) {
+        Matcher matcher = TERMS_SET_PATTERN.matcher(description);
+
+        if (!matcher.matches()) {
+            return description;
+        }
+
+        String separated = byRendering.get(matcher.group(2));
+
+        if (separated == null || separated.equals(AMBIGUOUS)) {
+            return description;
+        }
+
+        String boost = matcher.group(3);
+
+        return matcher.group(1) + ":(" + separated + ")" + (boost == null ? "" : "^" + boost);
     }
 
     /**

--- a/server/src/test/java/au/org/aodn/ogcapi/server/common/RestAdminApiTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/common/RestAdminApiTest.java
@@ -198,6 +198,30 @@ public class RestAdminApiTest extends BaseTestClass {
     }
 
     @Test
+    public void explainSimplifiedFormatSeparatesTheDatasetGroupTerms() throws IOException {
+        // the record sits in the "imos" dataset group, the free text search adds a terms clause
+        // holding the whole input plus each of its words
+        insertRecordsWithExplicitIds("7709f541-fc0c-4318-b5b9-9053aa474e0e.json");
+
+        URI simpleUri = explainUri("q", "imos temperature", "format", "simple");
+
+        ResponseEntity<JsonNode> response = testRestTemplate.getForEntity(simpleUri, JsonNode.class);
+
+        assertTrue(response.getStatusCode().is2xxSuccessful());
+        List<String> descriptions = fieldValues(
+                Objects.requireNonNull(response.getBody()).path("hits").path(0).path("filters"),
+                "description");
+
+        // elastic search joins the values with a space, which reads as one run of words
+        assertTrue(descriptions.stream()
+                .noneMatch(d -> d.contains("summaries.dataset_group:(imos imos temperature temperature")));
+        // the boost is left out of the assertion, its value is still being tuned
+        assertTrue(descriptions.stream()
+                        .anyMatch(d -> d.startsWith("summaries.dataset_group:(imos,imos temperature,temperature)^")),
+                "the dataset group values must be separated, got " + descriptions);
+    }
+
+    @Test
     public void explainSimplifiedFormatReportsQuotedPhraseMatches() throws IOException {
         insertRecordsWithExplicitIds("7709f541-fc0c-4318-b5b9-9053aa474e0e.json");
 

--- a/server/src/test/java/au/org/aodn/ogcapi/server/core/util/ExplainSimplifierTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/core/util/ExplainSimplifierTest.java
@@ -1,0 +1,40 @@
+package au.org.aodn.ogcapi.server.core.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ExplainSimplifierTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * A free text search of "csiro temperature", the dataset group clause holds the whole input
+     * alongside each of its words. Elastic search renders it as one run of words,
+     * "summaries.dataset_group:(csiro csiro temperature temperature)^100.0", which the request
+     * is needed to separate again.
+     */
+    private Map<String, String> datasetGroupRequest() throws JsonProcessingException {
+        JsonNode request = MAPPER.readTree("""
+                {"query":{"bool":{"should":[
+                  {"match":{"title":{"query":"csiro temperature"}}},
+                  {"terms":{"summaries.dataset_group":["csiro temperature","csiro","temperature"],
+                            "boost":100.0}}]}}}""");
+
+        return ExplainSimplifier.termsClausesOf(request);
+    }
+
+    @Test
+    public void separateTermsValuesCommaSeparatesTheValuesOfTheClause() throws JsonProcessingException {
+        assertEquals(
+                "summaries.dataset_group:(csiro,csiro temperature,temperature)^100.0",
+                ExplainSimplifier.separateTermsValues(
+                        "summaries.dataset_group:(csiro csiro temperature temperature)^100.0",
+                        datasetGroupRequest()));
+    }
+}

--- a/server/src/test/java/au/org/aodn/ogcapi/server/service/ElasticSearchTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/service/ElasticSearchTest.java
@@ -154,7 +154,7 @@ public class ElasticSearchTest {
                 "-score,-rank",
                 CQLCrsType.EPSG4326);
 
-        assertEquals(9, capturingSearch.should.size(),
+        assertEquals(10, capturingSearch.should.size(),
                 "Exact match should produce 9 queries (title + description + other fields)");
         assertTrue(capturingSearch.should.get(0).isMatchPhrase(), "Title query should be MatchPhraseQuery");
         assertTrue(capturingSearch.should.get(1).isMatchPhrase(), "Description query should be MatchPhraseQuery");
@@ -215,7 +215,7 @@ public class ElasticSearchTest {
         assertEquals("captured", result.path("status").asText());
         assertEquals(100, capturingSearch.explainRequest.size());
         assertTrue(capturingSearch.explainRequest.query().isScriptScore());
-        assertEquals(9, capturingSearch.explainRequest.query().scriptScore()
+        assertEquals(10, capturingSearch.explainRequest.query().scriptScore()
                 .query().bool().should().size());
         assertNotNull(capturingSearch.explainRequest.source());
         assertTrue(capturingSearch.explainRequest.source().isFilter());

--- a/server/src/test/java/au/org/aodn/ogcapi/server/service/ElasticSearchTest.java
+++ b/server/src/test/java/au/org/aodn/ogcapi/server/service/ElasticSearchTest.java
@@ -155,7 +155,7 @@ public class ElasticSearchTest {
                 CQLCrsType.EPSG4326);
 
         assertEquals(10, capturingSearch.should.size(),
-                "Exact match should produce 9 queries (title + description + other fields)");
+                "Exact match should produce 10 queries (title + description + other fields)");
         assertTrue(capturingSearch.should.get(0).isMatchPhrase(), "Title query should be MatchPhraseQuery");
         assertTrue(capturingSearch.should.get(1).isMatchPhrase(), "Description query should be MatchPhraseQuery");
     }
@@ -171,7 +171,7 @@ public class ElasticSearchTest {
                 "-score,-rank",
                 CQLCrsType.EPSG4326);
 
-        assertEquals(9, capturingSearch.should.size(), "Fuzzy match should produce 9 queries");
+        assertEquals(10, capturingSearch.should.size(), "Fuzzy match should produce 10 queries");
         assertTrue(capturingSearch.should.get(0).isMatch(), "fuzzy_title should be MatchQuery");
     }
 


### PR DESCRIPTION
Improves collection search ranking for AODN partner organisations by including `dataset_group` in free-text searches with a high boost. Simplified response from `_explain` endpoint and tests updated accordingly.

<img width="685" height="608" alt="image" src="https://github.com/user-attachments/assets/80995184-3bcb-4e6b-99d7-8680200d2c48" />
<img width="848" height="454" alt="image" src="https://github.com/user-attachments/assets/d39ff47f-c024-44b0-84f0-5d19d3bac459" />
